### PR TITLE
body-sub table, new row for each action

### DIFF
--- a/default.go
+++ b/default.go
@@ -343,14 +343,14 @@ func (dt *Default) HTMLTemplate() string {
                     {{ with .Email.Body.Actions }} 
                       <table class="body-sub">
                         <tbody>
-                          <tr>
                             {{ range $action := . }}
-                              <td>
-                                <p class="sub">If you’re having trouble with the button '{{ $action.Button.Text }}', copy and paste the URL below into your web browser.</p>
-                                <p class="sub"><a href="{{ $action.Button.Link }}">{{ $action.Button.Link }}</a></p>
-                              </td>
+			      <tr>
+                                <td>
+                                  <p class="sub">If you’re having trouble with the button '{{ $action.Button.Text }}', copy and paste the URL below into your web browser.</p>
+                                  <p class="sub"><a href="{{ $action.Button.Link }}">{{ $action.Button.Link }}</a></p>
+                                </td>
+			      </tr>
                             {{ end }}
-                          </tr>
                         </tbody>
                       </table>
                     {{ end }}


### PR DESCRIPTION
Fixes styling issues when more than one button is included in the body of the email by moving each button alternative link to a new row.

Issue: https://github.com/matcornic/hermes/issues/2