### PR TITLE
Use blackfriday v2

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -62,12 +62,6 @@
   version = "v1.0.0"
 
 [[projects]]
-  name = "github.com/russross/blackfriday"
-  packages = ["."]
-  revision = "cadec560ec52d93835bf2f15bd794700d3a2473b"
-  version = "v2.0.0"
-
-[[projects]]
   name = "github.com/satori/go.uuid"
   packages = ["."]
   revision = "879c5887cd475cd7864858769793b2ceb0d44feb"
@@ -103,9 +97,15 @@
   packages = ["html","html/atom"]
   revision = "d866cfc389cec985d6fda2859936a575a55a3ab6"
 
+[[projects]]
+  name = "gopkg.in/russross/blackfriday.v2"
+  packages = ["."]
+  revision = "cadec560ec52d93835bf2f15bd794700d3a2473b"
+  version = "v2.0.0"
+
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "936b042897ce8e2126fd38e5f3b757eb564a83800341f0ad7ef55b27181e8770"
+  inputs-digest = "74f494e631dfdf63c96d26579f7f802e52dfe70480f1b3cfc03ef331eb223dea"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -34,7 +34,7 @@
   name = "github.com/jaytaylor/html2text"
 
 [[constraint]]
-  name = "github.com/russross/blackfriday"
+  name = "gopkg.in/russross/blackfriday.v2"
   version = "2.0.0"
 
 [[constraint]]

--- a/hermes.go
+++ b/hermes.go
@@ -2,11 +2,12 @@ package hermes
 
 import (
 	"bytes"
+	"html/template"
+
 	"github.com/Masterminds/sprig"
 	"github.com/imdario/mergo"
 	"github.com/jaytaylor/html2text"
-	"github.com/russross/blackfriday"
-	"html/template"
+	blackfriday "gopkg.in/russross/blackfriday.v2"
 )
 
 // Hermes is an instance of the hermes email generator


### PR DESCRIPTION
Hello Mathieu,

Looks like you upgraded the `blackfriday` package in dep, but not in your regular imports, which breaks the build. This PR is a proposal to fix it.

Not sure if the `Gopkg.toml` should also be updated for the constraint path of `blackfriday`, I'm not (yet) a regular user of dep.

Thanks,
Pierre