### PR TITLE
Allow markdown in Intros and Outros as an alternate to plain text

### DIFF
--- a/default.go
+++ b/default.go
@@ -398,6 +398,9 @@ func (dt *Default) HTMLTemplate() string {
                     <p>
                       {{.Email.Body.Signature}},
                       <br />
+                      {{ if (ne .Email.Body.SignatureName "") }}
+                      {{.Email.Body.SignatureName}}<br />
+                      {{ end }}
                       {{.Hermes.Product.Name}}
                     </p>
 
@@ -504,7 +507,14 @@ func (dt *Default) PlainTextTemplate() string {
     {{ end }}
   {{ end }}
 {{ end }}
-<p>{{.Email.Body.Signature}},<br>{{.Hermes.Product.Name}} - {{.Hermes.Product.Link}}</p>
+<p>
+  {{.Email.Body.Signature}},
+  <br>
+  {{ if (ne .Email.Body.SignatureName "") }}
+    {{.Email.Body.SignatureName}}<br>
+  {{ end }}
+  {{.Hermes.Product.Name}} - {{.Hermes.Product.Link}}
+</p>
 
 <p>{{.Hermes.Product.Copyright}}</p>
 `

--- a/flat.go
+++ b/flat.go
@@ -398,6 +398,9 @@ func (dt *Flat) HTMLTemplate() string {
                     <p>
                       {{.Email.Body.Signature}},
                       <br />
+                      {{ if (ne .Email.Body.SignatureName "") }}
+                      {{.Email.Body.SignatureName}}<br />
+                      {{ end }}
                       {{.Hermes.Product.Name}}
                     </p>
 
@@ -504,7 +507,14 @@ func (dt *Flat) PlainTextTemplate() string {
     {{ end }}
   {{ end }}
 {{ end }}
-<p>{{.Email.Body.Signature}},<br>{{.Hermes.Product.Name}} - {{.Hermes.Product.Link}}</p>
+<p>
+  {{.Email.Body.Signature}},
+  <br>
+  {{ if (ne .Email.Body.SignatureName "") }}
+    {{.Email.Body.SignatureName}}<br>
+  {{ end }}
+  {{.Hermes.Product.Name}} - {{.Hermes.Product.Link}}
+</p>
 
 <p>{{.Hermes.Product.Copyright}}</p>
 `

--- a/hermes.go
+++ b/hermes.go
@@ -69,6 +69,7 @@ type Body struct {
 	OutrosMarkdown Markdown // Outro in markdown, will override Outros
 	Greeting       string   // Greeting for the contacted person (default to 'Hi')
 	Signature      string   // Signature for the contacted person (default to 'Yours truly')
+	SignatureName  string   // Contact person name
 	Title          string   // Title replaces the greeting+name when set
 	FreeMarkdown   Markdown // Free markdown content that replaces all content other than header and footer
 }


### PR DESCRIPTION
Should (at least partly) solve #17.