### PR TITLE
Add support for windows 10 mail/Outlook

### DIFF
--- a/default.go
+++ b/default.go
@@ -363,6 +363,15 @@ func (dt *Default) HTMLTemplate() string {
                         {{ if gt (len .) 0 }}
                           {{ range $action := . }}
                             <p>{{ $action.Instructions }}</p>
+                            {{"<!--[if mso]>" | html}}
+                              <v:roundrect xmlns:v="urn:schemas-microsoft-com:vml" xmlns:w="urn:schemas-microsoft-com:office:word" href="{{ $action.Button.Link }}" style="height:40px;v-text-anchor:middle;width:300px;" arcsize="10%" stroke="f" fillcolor="{{ $action.Button.Color }}">
+                                <w:anchorlock/>
+                                <center style="color:{{ $action.Button.TextColor }};font-family:sans-serif;font-size:16px;font-weight:bold;">
+                                  {{ $action.Button.Text }}
+                                </center>
+                              </v:roundrect>
+                            {{"<![endif]-->" | html}}
+                            {{"<!--[if !mso]><!-- -->" | html}}
                             <table class="body-action" align="center" width="100%" cellpadding="0" cellspacing="0">
                               <tr>
                                 <td align="center">
@@ -374,6 +383,7 @@ func (dt *Default) HTMLTemplate() string {
                                 </td>
                               </tr>
                             </table>
+                            {{"<!--<![endif]-->" | html}}
                           {{ end }}
                         {{ end }}
                       {{ end }}

--- a/hermes.go
+++ b/hermes.go
@@ -30,6 +30,9 @@ var templateFuncs = template.FuncMap{
 	"url": func(s string) template.URL {
 		return template.URL(s)
 	},
+	"html": func(s string) template.HTML {
+		return template.HTML(s)
+	},
 }
 
 // TDLeftToRight is the text direction from left to right (default)


### PR DESCRIPTION
This adds support into the default template for M$ based email clients e.g Windows 10 Mail and Outlook.
Without this the button is not visible at all in those clients.