### PR TITLE
fix css style '.button.color' does not work in Gmail web view

### DIFF
--- a/default.go
+++ b/default.go
@@ -237,7 +237,7 @@ func (dt *Default) HTMLTemplate() string {
       width: 200px;
       background-color: #3869D4;
       border-radius: 3px;
-      color: #ffffff;
+      color: #ffffff !important;
       font-size: 15px;
       line-height: 45px;
       text-align: center;

--- a/flat.go
+++ b/flat.go
@@ -242,7 +242,7 @@ func (dt *Flat) HTMLTemplate() string {
       display: inline-block;
       width: 100%;
       background-color: #00948d;
-      color: #ffffff;
+      color: #ffffff !important;
       font-size: 15px;
       line-height: 45px;
       text-align: center;


### PR DESCRIPTION
Currently, '.button.color' does not work in Gmail web view and Outlook app (ios)