### PR TITLE
Feat/improve css compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 
 go:
-  - 1.11
+  - 1.13
 
 script:
 - go test -race -coverprofile=coverage.txt -covermode=atomic

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -294,6 +294,28 @@ A good practice is to describe action in footer in case of problem when displayi
 {{ end }}
 ```
 
+Be aware that Outlook HTML engine is very old and is not compatible with many CSS features.
+It means, if you want to create a button, the best solution is to create a case only for Outlook. For example, in flat theme, the following code is used to create a button which is a Microsoft VML rectangle. It will not be as perfect as pure CSS interpreted by recent engines, but it will do the work.
+
+```
+{{safe "<!--[if mso]>" }}
+<div style="margin: 30px auto">
+    <v:roundrect xmlns:v="urn:schemas-microsoft-com:vml" 
+    xmlns:w="urn:schemas-microsoft-com:office:word" 
+    href="{{ $action.Button.Link }}" 
+    style="height:45px;v-text-anchor:middle;width:570px;background-color:{{ if $action.Button.Color }}{{ $action.Button.Color }}{{else}}#00948D{{ end }};"
+    arcsize="0%" 
+    {{ if $action.Button.Color }}strokecolor="{{ $action.Button.Color }}" fillcolor="{{ $action.Button.Color }}"{{ else }}strokecolor="#00948D" fillcolor="#00948D"{{ end }}
+    >
+    <w:anchorlock/>
+    <center style="color: {{ if $action.Button.TextColor }}{{ $action.Button.TextColor }}{{else}}#FFFFFF{{ end }};font-size: 15px;text-align: center;font-family:sans-serif;font-weight:bold;">
+        {{ $action.Button.Text }}
+    </center>
+    </v:roundrect>
+</div>
+{{safe "<![endif]-->" }}
+```
+
 ## Outro Injection
 
 The following will inject the outro text (string or array) into the e-mail:

--- a/README.md
+++ b/README.md
@@ -223,6 +223,16 @@ h := hermes.Hermes{
 }
 ```
 
+Since `v2.1.0`, Hermes is automatically inlining all CSS to improve compatibility with email clients, thanks to [Premailer](github.com/vanng822/go-premailer/premailer).
+You can disable this feature by setting `DisableCSSInlining` of `Hermes` struct to `true`.
+
+```go
+h := hermes.Hermes{
+    ...
+    DisableCSSInlining: true,
+}
+```
+
 ## Elements
 
 Hermes supports injecting custom elements such as dictionaries, tables and action buttons into e-mails.

--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ h := hermes.Hermes{
 }
 ```
 
-Since `v2.1.0`, Hermes is automatically inlining all CSS to improve compatibility with email clients, thanks to [Premailer](github.com/vanng822/go-premailer/premailer).
+Since `v2.1.0`, Hermes is automatically inlining all CSS to improve compatibility with email clients, thanks to [Premailer](https://github.com/vanng822/go-premailer/premailer).
 You can disable this feature by setting `DisableCSSInlining` of `Hermes` struct to `true`.
 
 ```go

--- a/default.go
+++ b/default.go
@@ -234,7 +234,6 @@ func (dt *Default) HTMLTemplate() string {
     /* Buttons ------------------------------ */
     .button {
       display: inline-block;
-      width: 200px;
       background-color: #3869D4;
       border-radius: 3px;
       color: #ffffff !important;
@@ -363,12 +362,15 @@ func (dt *Default) HTMLTemplate() string {
                         {{ if gt (len .) 0 }}
                           {{ range $action := . }}
                             <p>{{ $action.Instructions }}</p>
+                            {{ $length := len $action.Button.Text }}
+                            {{ $width := add (mul $length 9) 20 }}
+                            {{if (lt $width 200)}}{{$width = 200}}{{else if (gt $width 570)}}{{$width = 570}}{{else}}{{end}}
                             {{safe "<!--[if mso]>" }}
                             <div style="margin: 30px auto;v-text-anchor:middle;text-align:center">
                               <v:roundrect xmlns:v="urn:schemas-microsoft-com:vml" 
                                 xmlns:w="urn:schemas-microsoft-com:office:word" 
                                 href="{{ $action.Button.Link }}" 
-                                style="height:45px;v-text-anchor:middle;width:300px;background-color:{{ if $action.Button.Color }}{{ $action.Button.Color }}{{ else }}#3869D4{{ end }};"
+                                style="height:45px;v-text-anchor:middle;width:{{$width}}px;background-color:{{ if $action.Button.Color }}{{ $action.Button.Color }}{{ else }}#3869D4{{ end }};"
                                 arcsize="10%" 
                                 {{ if $action.Button.Color }}strokecolor="{{ $action.Button.Color }}" fillcolor="{{ $action.Button.Color }}"{{ else }}strokecolor="#3869D4" fillcolor="#3869D4"{{ end }}
                                 >
@@ -384,7 +386,7 @@ func (dt *Default) HTMLTemplate() string {
                               <tr>
                                 <td align="center">
                                   <div>
-                                    <a href="{{ $action.Button.Link }}" class="button" style="{{ with $action.Button.Color }}background-color: {{ . }};{{ end }} {{ with $action.Button.TextColor }}color: {{ . }};{{ end }}" target="_blank">
+                                    <a href="{{ $action.Button.Link }}" class="button" style="{{ with $action.Button.Color }}background-color: {{ . }};{{ end }} {{ with $action.Button.TextColor }}color: {{ . }};{{ end }} width: {{$width}}px;" target="_blank">
                                       {{ $action.Button.Text }}
                                     </a>
                                   </div>

--- a/default.go
+++ b/default.go
@@ -148,8 +148,8 @@ func (dt *Default) HTMLTemplate() string {
       font-weight: bold;
     }
     blockquote {
-      margin: 1.7rem 0;
-      padding-left: 0.85rem;
+      margin: 25px 0;
+      padding-left: 10px;
       border-left: 10px solid #F0F2F4;
     }
     blockquote p {
@@ -363,6 +363,23 @@ func (dt *Default) HTMLTemplate() string {
                         {{ if gt (len .) 0 }}
                           {{ range $action := . }}
                             <p>{{ $action.Instructions }}</p>
+                            {{safe "<!--[if mso]>" }}
+                            <div style="margin: 30px auto;v-text-anchor:middle;text-align:center">
+                              <v:roundrect xmlns:v="urn:schemas-microsoft-com:vml" 
+                                xmlns:w="urn:schemas-microsoft-com:office:word" 
+                                href="{{ $action.Button.Link }}" 
+                                style="height:45px;v-text-anchor:middle;width:300px;background-color:{{ if $action.Button.Color }}{{ $action.Button.Color }}{{ else }}#3869D4{{ end }};"
+                                arcsize="10%" 
+                                {{ if $action.Button.Color }}strokecolor="{{ $action.Button.Color }}" fillcolor="{{ $action.Button.Color }}"{{ else }}strokecolor="#3869D4" fillcolor="#3869D4"{{ end }}
+                                >
+                                <w:anchorlock/>
+                                <center style="color: {{ if $action.Button.TextColor }}{{ $action.Button.TextColor }}{{else}}#FFFFFF{{ end }};font-size: 15px;text-align: center;font-family:sans-serif;font-weight:bold;">
+                                  {{ $action.Button.Text }}
+                                </center>
+                              </v:roundrect>
+                            </div>
+                            {{safe "<![endif]-->" }}
+                            {{safe "<!--[if !mso]><!-- -->"}}
                             <table class="body-action" align="center" width="100%" cellpadding="0" cellspacing="0">
                               <tr>
                                 <td align="center">
@@ -374,6 +391,7 @@ func (dt *Default) HTMLTemplate() string {
                                 </td>
                               </tr>
                             </table>
+                            {{safe "<![endif]-->" }}
                           {{ end }}
                         {{ end }}
                       {{ end }}

--- a/examples/default/default.maintenance.html
+++ b/examples/default/default.maintenance.html
@@ -1,263 +1,36 @@
-
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-  <style type="text/css" rel="stylesheet" media="all">
-     
-    *:not(br):not(tr):not(html) {
-      font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif;
-      -webkit-box-sizing: border-box;
-      box-sizing: border-box;
-    }
-    body {
-      width: 100% !important;
-      height: 100%;
-      margin: 0;
-      line-height: 1.4;
-      background-color: #F2F4F6;
-      color: #74787E;
-      -webkit-text-size-adjust: none;
-    }
-    a {
-      color: #3869D4;
-    }
-     
-    .email-wrapper {
-      width: 100%;
-      margin: 0;
-      padding: 0;
-      background-color: #F2F4F6;
-    }
-    .email-content {
-      width: 100%;
-      margin: 0;
-      padding: 0;
-    }
-     
-    .email-masthead {
-      padding: 25px 0;
-      text-align: center;
-    }
-    .email-masthead_logo {
-      max-width: 400px;
-      border: 0;
-    }
-    .email-masthead_name {
-      font-size: 16px;
-      font-weight: bold;
-      color: #2F3133;
-      text-decoration: none;
-      text-shadow: 0 1px 0 white;
-    }
-    .email-logo {
-      max-height: 50px;
-    }
-     
-    .email-body {
-      width: 100%;
-      margin: 0;
-      padding: 0;
-      border-top: 1px solid #EDEFF2;
-      border-bottom: 1px solid #EDEFF2;
-      background-color: #FFF;
-    }
-    .email-body_inner {
-      width: 570px;
-      margin: 0 auto;
-      padding: 0;
-    }
-    .email-footer {
-      width: 570px;
-      margin: 0 auto;
-      padding: 0;
-      text-align: center;
-    }
-    .email-footer p {
-      color: #AEAEAE;
-    }
-    .body-action {
-      width: 100%;
-      margin: 30px auto;
-      padding: 0;
-      text-align: center;
-    }
-    .body-dictionary {
-      width: 100%;
-      overflow: hidden;
-      margin: 20px auto 10px;
-      padding: 0;
-    }
-    .body-dictionary dd {
-      margin: 0 0 10px 0;
-    }
-    .body-dictionary dt {
-      clear: both;
-      color: #000;
-      font-weight: bold;
-    }
-    .body-dictionary dd {
-      margin-left: 0;
-      margin-bottom: 10px;
-    }
-    .body-sub {
-      margin-top: 25px;
-      padding-top: 25px;
-      border-top: 1px solid #EDEFF2;
-      table-layout: fixed;
-    }
-    .body-sub a {
-      word-break: break-all;
-    }
-    .content-cell {
-      padding: 35px;
-    }
-    .align-right {
-      text-align: right;
-    }
-     
-    h1 {
-      margin-top: 0;
-      color: #2F3133;
-      font-size: 19px;
-      font-weight: bold;
-    }
-    h2 {
-      margin-top: 0;
-      color: #2F3133;
-      font-size: 16px;
-      font-weight: bold;
-    }
-    h3 {
-      margin-top: 0;
-      color: #2F3133;
-      font-size: 14px;
-      font-weight: bold;
-    }
-    blockquote {
-      margin: 1.7rem 0;
-      padding-left: 0.85rem;
-      border-left: 10px solid #F0F2F4;
-    }
-    blockquote p {
-        font-size: 1.1rem;
-        color: #999;
-    }
-    blockquote cite {
-        display: block;
-        text-align: right;
-        color: #666;
-        font-size: 1.2rem;
-    }
-    cite {
-      display: block;
-      font-size: 0.925rem; 
-    }
-    cite:before {
-      content: "\2014 \0020";
-    }
-    p {
-      margin-top: 0;
-      color: #74787E;
-      font-size: 16px;
-      line-height: 1.5em;
-    }
-    p.sub {
-      font-size: 12px;
-    }
-    p.center {
-      text-align: center;
-    }
-    table {
-      width: 100%;
-    }
-    th {
-      padding: 0px 5px;
-      padding-bottom: 8px;
-      border-bottom: 1px solid #EDEFF2;
-    }
-    th p {
-      margin: 0;
-      color: #9BA2AB;
-      font-size: 12px;
-    }
-    td {
-      padding: 10px 5px;
-      color: #74787E;
-      font-size: 15px;
-      line-height: 18px;
-    }
-    .content {
-      align: center;
-      padding: 0;
-    }
-     
-    .data-wrapper {
-      width: 100%;
-      margin: 0;
-      padding: 35px 0;
-    }
-    .data-table {
-      width: 100%;
-      margin: 0;
-    }
-    .data-table th {
-      text-align: left;
-      padding: 0px 5px;
-      padding-bottom: 8px;
-      border-bottom: 1px solid #EDEFF2;
-    }
-    .data-table th p {
-      margin: 0;
-      color: #9BA2AB;
-      font-size: 12px;
-    }
-    .data-table td {
-      padding: 10px 5px;
-      color: #74787E;
-      font-size: 15px;
-      line-height: 18px;
-    }
-     
-    .button {
-      display: inline-block;
-      width: 200px;
-      background-color: #3869D4;
-      border-radius: 3px;
-      color: #ffffff;
-      font-size: 15px;
-      line-height: 45px;
-      text-align: center;
-      text-decoration: none;
-      -webkit-text-size-adjust: none;
-      mso-hide: all;
-    }
-     
-    @media only screen and (max-width: 600px) {
-      .email-body_inner,
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><html xmlns="http://www.w3.org/1999/xhtml"><head>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+  
+<style type="text/css">*:not(br):not(tr):not(html) {
+font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif !important;
+-webkit-box-sizing: border-box !important;
+box-sizing: border-box !important
+}cite:before {
+content: "\2014 \0020" !important
+}@media only screen and (max-width: 600px){
+.email-body_inner,
       .email-footer {
-        width: 100% !important;
-      }
-    }
-    @media only screen and (max-width: 500px) {
-      .button {
-        width: 100% !important;
-      }
-    }
-  </style>
-</head>
-<body dir="ltr">
-  <table class="email-wrapper" width="100%" cellpadding="0" cellspacing="0">
-    <tr>
-      <td class="content">
-        <table class="email-content" width="100%" cellpadding="0" cellspacing="0">
+width: 100% !important
+}
+}
+@media only screen and (max-width: 500px){
+.button {
+width: 100% !important
+}
+}
+</style></head>
+<body dir="ltr" style="height:100%;margin:0;line-height:1.4;background-color:#F2F4F6;color:#74787E;-webkit-text-size-adjust:none;width:100%">
+  <table class="email-wrapper" width="100%" cellpadding="0" cellspacing="0" style="width:100%;margin:0;padding:0;background-color:#F2F4F6">
+    <tbody><tr>
+      <td class="content" style="color:#74787E;font-size:15px;line-height:18px;align:center;padding:0">
+        <table class="email-content" width="100%" cellpadding="0" cellspacing="0" style="width:100%;margin:0;padding:0">
           
-          <tr>
-            <td class="email-masthead">
-              <a class="email-masthead_name" href="https://example-hermes.com/" target="_blank">
+          <tbody><tr>
+            <td class="email-masthead" style="color:#74787E;font-size:15px;line-height:18px;padding:25px 0;text-align:center">
+              <a class="email-masthead_name" href="https://example-hermes.com/" target="_blank" style="font-size:16px;font-weight:bold;color:#2F3133;text-decoration:none;text-shadow:0 1px 0 white">
                 
-                  <img src="http://www.duchess-france.org/wp-content/uploads/2016/01/gopher.png" class="email-logo" />
+                  <img src="https://github.com/matcornic/hermes/blob/master/examples/gopher.png?raw=true" class="email-logo" style="max-height:50px"/>
                 
                 </a>
             </td>
@@ -265,81 +38,79 @@
 
           
           <tr>
-            <td class="email-body" width="100%">
-              <table class="email-body_inner" align="center" width="570" cellpadding="0" cellspacing="0">
+            <td class="email-body" width="100%" style="color:#74787E;font-size:15px;line-height:18px;width:100%;margin:0;padding:0;border-top:1px solid #EDEFF2;border-bottom:1px solid #EDEFF2;background-color:#FFF">
+              <table class="email-body_inner" align="center" width="570" cellpadding="0" cellspacing="0" style="width:570px;margin:0 auto;padding:0">
                 
-                <tr>
-                  <td class="content-cell">
-                    <h1>Hi Jon Snow,</h1>
+                <tbody><tr>
+                  <td class="content-cell" style="color:#74787E;font-size:15px;line-height:18px;padding:35px">
+                    <h1 style="margin-top:0;color:#2F3133;font-size:19px;font-weight:bold">Hi Jon Snow,</h1>
                     
                     
-                      <blockquote>
-<p><em>Hermes</em> service will shutdown the <strong>1st August 2017</strong> for maintenance operations.</p>
+                      <blockquote style="margin:25px 0;padding-left:10px;border-left:10px solid #F0F2F4">
+<p style="margin-top:0;line-height:1.5em;font-size:1.1rem;color:#999"><em>Hermes</em> service will shutdown the <strong>1st August 2017</strong> for maintenance operations.</p>
 </blockquote>
 
-<p>Services will be unavailable based on the following schedule:</p>
+<p style="margin-top:0;color:#74787E;font-size:16px;line-height:1.5em">Services will be unavailable based on the following schedule:</p>
 
-<table>
+<table style="width:100%">
 <thead>
 <tr>
-<th align="center">Services</th>
-<th align="center">Downtime</th>
+<th align="center" style="padding:0px 5px;padding-bottom:8px;border-bottom:1px solid #EDEFF2">Services</th>
+<th align="center" style="padding:0px 5px;padding-bottom:8px;border-bottom:1px solid #EDEFF2">Downtime</th>
 </tr>
 </thead>
 
 <tbody>
 <tr>
-<td align="center">Service A</td>
-<td align="center">2AM to 3AM</td>
+<td align="center" style="padding:10px 5px;color:#74787E;font-size:15px;line-height:18px">Service A</td>
+<td align="center" style="padding:10px 5px;color:#74787E;font-size:15px;line-height:18px">2AM to 3AM</td>
 </tr>
 
 <tr>
-<td align="center">Service B</td>
-<td align="center">4AM to 5AM</td>
+<td align="center" style="padding:10px 5px;color:#74787E;font-size:15px;line-height:18px">Service B</td>
+<td align="center" style="padding:10px 5px;color:#74787E;font-size:15px;line-height:18px">4AM to 5AM</td>
 </tr>
 
 <tr>
-<td align="center">Service C</td>
-<td align="center">5AM to 6AM</td>
+<td align="center" style="padding:10px 5px;color:#74787E;font-size:15px;line-height:18px">Service C</td>
+<td align="center" style="padding:10px 5px;color:#74787E;font-size:15px;line-height:18px">5AM to 6AM</td>
 </tr>
 </tbody>
 </table>
-
-<hr />
-
-<p>Feel free to contact us for any question regarding this matter at <a href="mailto:support@hermes-example.com">support@hermes-example.com</a> or in our <a href="https://gitter.im/">Gitter</a></p>
+<p style="margin-top:0;color:#74787E;font-size:16px;line-height:1.5em">Feel free to contact us for any question regarding this matter at <a href="mailto:support@hermes-example.com" style="color:#3869D4">support@hermes-example.com</a> or in our <a href="https://gitter.im/" style="color:#3869D4">Gitter</a></p>
 
                     
                     
 
-                    <p>
+                    <p style="margin-top:0;color:#74787E;font-size:16px;line-height:1.5em">
                       Yours truly,
-                      <br />
+                      <br/>
                       Hermes
                     </p>
 
                     
                   </td>
                 </tr>
-              </table>
+              </tbody></table>
             </td>
           </tr>
           <tr>
-            <td>
-              <table class="email-footer" align="center" width="570" cellpadding="0" cellspacing="0">
-                <tr>
-                  <td class="content-cell">
-                    <p class="sub center">
-                      Copyright © 2019 Hermes. All rights reserved.
+            <td style="padding:10px 5px;color:#74787E;font-size:15px;line-height:18px">
+              <table class="email-footer" align="center" width="570" cellpadding="0" cellspacing="0" style="width:570px;margin:0 auto;padding:0;text-align:center">
+                <tbody><tr>
+                  <td class="content-cell" style="color:#74787E;font-size:15px;line-height:18px;padding:35px">
+                    <p class="sub center" style="margin-top:0;line-height:1.5em;color:#AEAEAE;font-size:12px;text-align:center">
+                      Copyright © 2020 Hermes. All rights reserved.
                     </p>
                   </td>
                 </tr>
-              </table>
+              </tbody></table>
             </td>
           </tr>
-        </table>
+        </tbody></table>
       </td>
     </tr>
-  </table>
-</body>
-</html>
+  </tbody></table>
+
+
+</body></html>

--- a/examples/default/default.maintenance.txt
+++ b/examples/default/default.maintenance.txt
@@ -25,4 +25,4 @@ Feel free to contact us for any question regarding this matter at support@hermes
 Yours truly,
 Hermes - https://example-hermes.com/
 
-Copyright © 2019 Hermes. All rights reserved.
+Copyright © 2020 Hermes. All rights reserved.

--- a/examples/default/default.receipt.html
+++ b/examples/default/default.receipt.html
@@ -125,12 +125,15 @@ width: 100% !important
                         
                           
                             <p style="margin-top:0;color:#74787E;font-size:16px;line-height:1.5em">You can check the status of your order and more in your dashboard:</p>
+                            
+                            
+                            
                             <!--[if mso]>
                             <div style="margin: 30px auto;v-text-anchor:middle;text-align:center">
                               <v:roundrect xmlns:v="urn:schemas-microsoft-com:vml" 
                                 xmlns:w="urn:schemas-microsoft-com:office:word" 
                                 href="https://hermes-example.com/dashboard" 
-                                style="height:45px;v-text-anchor:middle;width:300px;background-color:#3869D4;"
+                                style="height:45px;v-text-anchor:middle;width:200px;background-color:#3869D4;"
                                 arcsize="10%" 
                                 strokecolor="#3869D4" fillcolor="#3869D4"
                                 >
@@ -146,7 +149,7 @@ width: 100% !important
                               <tbody><tr>
                                 <td align="center" style="padding:10px 5px;color:#74787E;font-size:15px;line-height:18px">
                                   <div>
-                                    <a href="https://hermes-example.com/dashboard" class="button" style="display:inline-block;width:200px;background-color:#3869D4;border-radius:3px;font-size:15px;line-height:45px;text-align:center;text-decoration:none;-webkit-text-size-adjust:none;mso-hide:all;color:#ffffff" target="_blank" width="200">
+                                    <a href="https://hermes-example.com/dashboard" class="button" style="display:inline-block;background-color:#3869D4;border-radius:3px;font-size:15px;line-height:45px;text-align:center;text-decoration:none;-webkit-text-size-adjust:none;mso-hide:all;color:#ffffff;width:200px" target="_blank" width="200">
                                       Go to Dashboard
                                     </a>
                                   </div>

--- a/examples/default/default.receipt.html
+++ b/examples/default/default.receipt.html
@@ -1,263 +1,36 @@
-
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-  <style type="text/css" rel="stylesheet" media="all">
-     
-    *:not(br):not(tr):not(html) {
-      font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif;
-      -webkit-box-sizing: border-box;
-      box-sizing: border-box;
-    }
-    body {
-      width: 100% !important;
-      height: 100%;
-      margin: 0;
-      line-height: 1.4;
-      background-color: #F2F4F6;
-      color: #74787E;
-      -webkit-text-size-adjust: none;
-    }
-    a {
-      color: #3869D4;
-    }
-     
-    .email-wrapper {
-      width: 100%;
-      margin: 0;
-      padding: 0;
-      background-color: #F2F4F6;
-    }
-    .email-content {
-      width: 100%;
-      margin: 0;
-      padding: 0;
-    }
-     
-    .email-masthead {
-      padding: 25px 0;
-      text-align: center;
-    }
-    .email-masthead_logo {
-      max-width: 400px;
-      border: 0;
-    }
-    .email-masthead_name {
-      font-size: 16px;
-      font-weight: bold;
-      color: #2F3133;
-      text-decoration: none;
-      text-shadow: 0 1px 0 white;
-    }
-    .email-logo {
-      max-height: 50px;
-    }
-     
-    .email-body {
-      width: 100%;
-      margin: 0;
-      padding: 0;
-      border-top: 1px solid #EDEFF2;
-      border-bottom: 1px solid #EDEFF2;
-      background-color: #FFF;
-    }
-    .email-body_inner {
-      width: 570px;
-      margin: 0 auto;
-      padding: 0;
-    }
-    .email-footer {
-      width: 570px;
-      margin: 0 auto;
-      padding: 0;
-      text-align: center;
-    }
-    .email-footer p {
-      color: #AEAEAE;
-    }
-    .body-action {
-      width: 100%;
-      margin: 30px auto;
-      padding: 0;
-      text-align: center;
-    }
-    .body-dictionary {
-      width: 100%;
-      overflow: hidden;
-      margin: 20px auto 10px;
-      padding: 0;
-    }
-    .body-dictionary dd {
-      margin: 0 0 10px 0;
-    }
-    .body-dictionary dt {
-      clear: both;
-      color: #000;
-      font-weight: bold;
-    }
-    .body-dictionary dd {
-      margin-left: 0;
-      margin-bottom: 10px;
-    }
-    .body-sub {
-      margin-top: 25px;
-      padding-top: 25px;
-      border-top: 1px solid #EDEFF2;
-      table-layout: fixed;
-    }
-    .body-sub a {
-      word-break: break-all;
-    }
-    .content-cell {
-      padding: 35px;
-    }
-    .align-right {
-      text-align: right;
-    }
-     
-    h1 {
-      margin-top: 0;
-      color: #2F3133;
-      font-size: 19px;
-      font-weight: bold;
-    }
-    h2 {
-      margin-top: 0;
-      color: #2F3133;
-      font-size: 16px;
-      font-weight: bold;
-    }
-    h3 {
-      margin-top: 0;
-      color: #2F3133;
-      font-size: 14px;
-      font-weight: bold;
-    }
-    blockquote {
-      margin: 1.7rem 0;
-      padding-left: 0.85rem;
-      border-left: 10px solid #F0F2F4;
-    }
-    blockquote p {
-        font-size: 1.1rem;
-        color: #999;
-    }
-    blockquote cite {
-        display: block;
-        text-align: right;
-        color: #666;
-        font-size: 1.2rem;
-    }
-    cite {
-      display: block;
-      font-size: 0.925rem; 
-    }
-    cite:before {
-      content: "\2014 \0020";
-    }
-    p {
-      margin-top: 0;
-      color: #74787E;
-      font-size: 16px;
-      line-height: 1.5em;
-    }
-    p.sub {
-      font-size: 12px;
-    }
-    p.center {
-      text-align: center;
-    }
-    table {
-      width: 100%;
-    }
-    th {
-      padding: 0px 5px;
-      padding-bottom: 8px;
-      border-bottom: 1px solid #EDEFF2;
-    }
-    th p {
-      margin: 0;
-      color: #9BA2AB;
-      font-size: 12px;
-    }
-    td {
-      padding: 10px 5px;
-      color: #74787E;
-      font-size: 15px;
-      line-height: 18px;
-    }
-    .content {
-      align: center;
-      padding: 0;
-    }
-     
-    .data-wrapper {
-      width: 100%;
-      margin: 0;
-      padding: 35px 0;
-    }
-    .data-table {
-      width: 100%;
-      margin: 0;
-    }
-    .data-table th {
-      text-align: left;
-      padding: 0px 5px;
-      padding-bottom: 8px;
-      border-bottom: 1px solid #EDEFF2;
-    }
-    .data-table th p {
-      margin: 0;
-      color: #9BA2AB;
-      font-size: 12px;
-    }
-    .data-table td {
-      padding: 10px 5px;
-      color: #74787E;
-      font-size: 15px;
-      line-height: 18px;
-    }
-     
-    .button {
-      display: inline-block;
-      width: 200px;
-      background-color: #3869D4;
-      border-radius: 3px;
-      color: #ffffff;
-      font-size: 15px;
-      line-height: 45px;
-      text-align: center;
-      text-decoration: none;
-      -webkit-text-size-adjust: none;
-      mso-hide: all;
-    }
-     
-    @media only screen and (max-width: 600px) {
-      .email-body_inner,
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><html xmlns="http://www.w3.org/1999/xhtml"><head>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+  
+<style type="text/css">*:not(br):not(tr):not(html) {
+font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif !important;
+-webkit-box-sizing: border-box !important;
+box-sizing: border-box !important
+}cite:before {
+content: "\2014 \0020" !important
+}@media only screen and (max-width: 600px){
+.email-body_inner,
       .email-footer {
-        width: 100% !important;
-      }
-    }
-    @media only screen and (max-width: 500px) {
-      .button {
-        width: 100% !important;
-      }
-    }
-  </style>
-</head>
-<body dir="ltr">
-  <table class="email-wrapper" width="100%" cellpadding="0" cellspacing="0">
-    <tr>
-      <td class="content">
-        <table class="email-content" width="100%" cellpadding="0" cellspacing="0">
+width: 100% !important
+}
+}
+@media only screen and (max-width: 500px){
+.button {
+width: 100% !important
+}
+}
+</style></head>
+<body dir="ltr" style="height:100%;margin:0;line-height:1.4;background-color:#F2F4F6;color:#74787E;-webkit-text-size-adjust:none;width:100%">
+  <table class="email-wrapper" width="100%" cellpadding="0" cellspacing="0" style="width:100%;margin:0;padding:0;background-color:#F2F4F6">
+    <tbody><tr>
+      <td class="content" style="color:#74787E;font-size:15px;line-height:18px;align:center;padding:0">
+        <table class="email-content" width="100%" cellpadding="0" cellspacing="0" style="width:100%;margin:0;padding:0">
           
-          <tr>
-            <td class="email-masthead">
-              <a class="email-masthead_name" href="https://example-hermes.com/" target="_blank">
+          <tbody><tr>
+            <td class="email-masthead" style="color:#74787E;font-size:15px;line-height:18px;padding:25px 0;text-align:center">
+              <a class="email-masthead_name" href="https://example-hermes.com/" target="_blank" style="font-size:16px;font-weight:bold;color:#2F3133;text-decoration:none;text-shadow:0 1px 0 white">
                 
-                  <img src="http://www.duchess-france.org/wp-content/uploads/2016/01/gopher.png" class="email-logo" />
+                  <img src="https://github.com/matcornic/hermes/blob/master/examples/gopher.png?raw=true" class="email-logo" style="max-height:50px"/>
                 
                 </a>
             </td>
@@ -265,16 +38,16 @@
 
           
           <tr>
-            <td class="email-body" width="100%">
-              <table class="email-body_inner" align="center" width="570" cellpadding="0" cellspacing="0">
+            <td class="email-body" width="100%" style="color:#74787E;font-size:15px;line-height:18px;width:100%;margin:0;padding:0;border-top:1px solid #EDEFF2;border-bottom:1px solid #EDEFF2;background-color:#FFF">
+              <table class="email-body_inner" align="center" width="570" cellpadding="0" cellspacing="0" style="width:570px;margin:0 auto;padding:0">
                 
-                <tr>
-                  <td class="content-cell">
-                    <h1>Hi Jon Snow,</h1>
+                <tbody><tr>
+                  <td class="content-cell" style="color:#74787E;font-size:15px;line-height:18px;padding:35px">
+                    <h1 style="margin-top:0;color:#2F3133;font-size:19px;font-weight:bold">Hi Jon Snow,</h1>
                     
                         
                           
-                            <p>Your order has been processed successfully.</p>
+                            <p style="margin-top:0;color:#74787E;font-size:16px;line-height:1.5em">Your order has been processed successfully.</p>
                           
                         
                     
@@ -287,82 +60,38 @@
                         
                         
                         
-                          <table class="data-wrapper" width="100%" cellpadding="0" cellspacing="0">
-                            <tr>
-                              <td colspan="2">
-                                <table class="data-table" width="100%" cellpadding="0" cellspacing="0">
-                                  <tr>
+                          <table class="data-wrapper" width="100%" cellpadding="0" cellspacing="0" style="width:100%;margin:0;padding:35px 0">
+                            <tbody><tr>
+                              <td colspan="2" style="padding:10px 5px;color:#74787E;font-size:15px;line-height:18px">
+                                <table class="data-table" width="100%" cellpadding="0" cellspacing="0" style="width:100%;margin:0">
+                                  <tbody><tr>
                                     
                                     
-                                      <th
-                                        
-                                          
-                                          
-                                            width="20%"
-                                          
-                                          
-                                          
-                                        
-                                      >
-                                        <p>Item</p>
+                                      <th width="20%" style="text-align:left;padding:0px 5px;padding-bottom:8px;border-bottom:1px solid #EDEFF2">
+                                        <p style="margin-top:0;line-height:1.5em;margin:0;color:#9BA2AB;font-size:12px">Item</p>
                                       </th>
                                     
-                                      <th
-                                        
-                                          
-                                          
-                                          
-                                          
-                                        
-                                      >
-                                        <p>Description</p>
+                                      <th style="text-align:left;padding:0px 5px;padding-bottom:8px;border-bottom:1px solid #EDEFF2">
+                                        <p style="margin-top:0;line-height:1.5em;margin:0;color:#9BA2AB;font-size:12px">Description</p>
                                       </th>
                                     
-                                      <th
-                                        
-                                          
-                                          
-                                            width="15%"
-                                          
-                                          
-                                          
-                                            style="text-align:right"
-                                          
-                                        
-                                      >
-                                        <p>Price</p>
+                                      <th width="15%" style="padding:0px 5px;padding-bottom:8px;border-bottom:1px solid #EDEFF2;text-align:right">
+                                        <p style="margin-top:0;line-height:1.5em;margin:0;color:#9BA2AB;font-size:12px">Price</p>
                                       </th>
                                     
                                   </tr>
                                   
                                     <tr>
                                       
-                                        <td
-                                          
-                                            
-                                            
-                                          
-                                        >
+                                        <td style="padding:10px 5px;color:#74787E;font-size:15px;line-height:18px">
                                           Golang
                                         </td>
                                       
-                                        <td
-                                          
-                                            
-                                            
-                                          
-                                        >
+                                        <td style="padding:10px 5px;color:#74787E;font-size:15px;line-height:18px">
                                           Open source programming language that makes it easy to build simple, reliable, and efficient software
                                         </td>
                                       
-                                        <td
-                                          
-                                            
-                                            
-                                              style="text-align:right"
-                                            
-                                          
-                                        >
+                                        <td style="padding:10px 5px;color:#74787E;font-size:15px;line-height:18px;text-align:right">
                                           $10.99
                                         </td>
                                       
@@ -370,41 +99,24 @@
                                   
                                     <tr>
                                       
-                                        <td
-                                          
-                                            
-                                            
-                                          
-                                        >
+                                        <td style="padding:10px 5px;color:#74787E;font-size:15px;line-height:18px">
                                           Hermes
                                         </td>
                                       
-                                        <td
-                                          
-                                            
-                                            
-                                          
-                                        >
+                                        <td style="padding:10px 5px;color:#74787E;font-size:15px;line-height:18px">
                                           Programmatically create beautiful e-mails using Golang.
                                         </td>
                                       
-                                        <td
-                                          
-                                            
-                                            
-                                              style="text-align:right"
-                                            
-                                          
-                                        >
+                                        <td style="padding:10px 5px;color:#74787E;font-size:15px;line-height:18px;text-align:right">
                                           $1.99
                                         </td>
                                       
                                     </tr>
                                   
-                                </table>
+                                </tbody></table>
                               </td>
                             </tr>
-                          </table>
+                          </tbody></table>
                         
                       
 
@@ -412,18 +124,36 @@
                       
                         
                           
-                            <p>You can check the status of your order and more in your dashboard:</p>
-                            <table class="body-action" align="center" width="100%" cellpadding="0" cellspacing="0">
-                              <tr>
-                                <td align="center">
+                            <p style="margin-top:0;color:#74787E;font-size:16px;line-height:1.5em">You can check the status of your order and more in your dashboard:</p>
+                            <!--[if mso]>
+                            <div style="margin: 30px auto;v-text-anchor:middle;text-align:center">
+                              <v:roundrect xmlns:v="urn:schemas-microsoft-com:vml" 
+                                xmlns:w="urn:schemas-microsoft-com:office:word" 
+                                href="https://hermes-example.com/dashboard" 
+                                style="height:45px;v-text-anchor:middle;width:300px;background-color:#3869D4;"
+                                arcsize="10%" 
+                                strokecolor="#3869D4" fillcolor="#3869D4"
+                                >
+                                <w:anchorlock/>
+                                <center style="color: #FFFFFF;font-size: 15px;text-align: center;font-family:sans-serif;font-weight:bold;">
+                                  Go to Dashboard
+                                </center>
+                              </v:roundrect>
+                            </div>
+                            <![endif]-->
+                            <!--[if !mso]><!-- -->
+                            <table class="body-action" align="center" width="100%" cellpadding="0" cellspacing="0" style="width:100%;margin:30px auto;padding:0;text-align:center">
+                              <tbody><tr>
+                                <td align="center" style="padding:10px 5px;color:#74787E;font-size:15px;line-height:18px">
                                   <div>
-                                    <a href="https://hermes-example.com/dashboard" class="button" style=" " target="_blank">
+                                    <a href="https://hermes-example.com/dashboard" class="button" style="display:inline-block;width:200px;background-color:#3869D4;border-radius:3px;font-size:15px;line-height:45px;text-align:center;text-decoration:none;-webkit-text-size-adjust:none;mso-hide:all;color:#ffffff" target="_blank" width="200">
                                       Go to Dashboard
                                     </a>
                                   </div>
                                 </td>
                               </tr>
-                            </table>
+                            </tbody></table>
+                            <!--[endif]---->
                           
                         
                       
@@ -431,21 +161,21 @@
                     
                     
 
-                    <p>
+                    <p style="margin-top:0;color:#74787E;font-size:16px;line-height:1.5em">
                       Yours truly,
-                      <br />
+                      <br/>
                       Hermes
                     </p>
 
                     
                        
-                        <table class="body-sub">
+                        <table class="body-sub" style="width:100%;margin-top:25px;padding-top:25px;border-top:1px solid #EDEFF2;table-layout:fixed">
                           <tbody>
                               
                                 <tr>
-                                  <td>
-                                    <p class="sub">If you’re having trouble with the button &#39;Go to Dashboard&#39;, copy and paste the URL below into your web browser.</p>
-                                    <p class="sub"><a href="https://hermes-example.com/dashboard">https://hermes-example.com/dashboard</a></p>
+                                  <td style="padding:10px 5px;color:#74787E;font-size:15px;line-height:18px">
+                                    <p class="sub" style="margin-top:0;color:#74787E;line-height:1.5em;font-size:12px">If you’re having trouble with the button &#39;Go to Dashboard&#39;, copy and paste the URL below into your web browser.</p>
+                                    <p class="sub" style="margin-top:0;color:#74787E;line-height:1.5em;font-size:12px"><a href="https://hermes-example.com/dashboard" style="color:#3869D4;word-break:break-all">https://hermes-example.com/dashboard</a></p>
                                   </td>
                                 </tr>
                               
@@ -455,25 +185,26 @@
                     
                   </td>
                 </tr>
-              </table>
+              </tbody></table>
             </td>
           </tr>
           <tr>
-            <td>
-              <table class="email-footer" align="center" width="570" cellpadding="0" cellspacing="0">
-                <tr>
-                  <td class="content-cell">
-                    <p class="sub center">
-                      Copyright © 2019 Hermes. All rights reserved.
+            <td style="padding:10px 5px;color:#74787E;font-size:15px;line-height:18px">
+              <table class="email-footer" align="center" width="570" cellpadding="0" cellspacing="0" style="width:570px;margin:0 auto;padding:0;text-align:center">
+                <tbody><tr>
+                  <td class="content-cell" style="color:#74787E;font-size:15px;line-height:18px;padding:35px">
+                    <p class="sub center" style="margin-top:0;line-height:1.5em;color:#AEAEAE;font-size:12px;text-align:center">
+                      Copyright © 2020 Hermes. All rights reserved.
                     </p>
                   </td>
                 </tr>
-              </table>
+              </tbody></table>
             </td>
           </tr>
-        </table>
+        </tbody></table>
       </td>
     </tr>
-  </table>
-</body>
-</html>
+  </tbody></table>
+
+
+</body></html>

--- a/examples/default/default.receipt.txt
+++ b/examples/default/default.receipt.txt
@@ -21,4 +21,4 @@ You can check the status of your order and more in your dashboard: https://herme
 Yours truly,
 Hermes - https://example-hermes.com/
 
-Copyright © 2019 Hermes. All rights reserved.
+Copyright © 2020 Hermes. All rights reserved.

--- a/examples/default/default.reset.html
+++ b/examples/default/default.reset.html
@@ -1,263 +1,36 @@
-
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-  <style type="text/css" rel="stylesheet" media="all">
-     
-    *:not(br):not(tr):not(html) {
-      font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif;
-      -webkit-box-sizing: border-box;
-      box-sizing: border-box;
-    }
-    body {
-      width: 100% !important;
-      height: 100%;
-      margin: 0;
-      line-height: 1.4;
-      background-color: #F2F4F6;
-      color: #74787E;
-      -webkit-text-size-adjust: none;
-    }
-    a {
-      color: #3869D4;
-    }
-     
-    .email-wrapper {
-      width: 100%;
-      margin: 0;
-      padding: 0;
-      background-color: #F2F4F6;
-    }
-    .email-content {
-      width: 100%;
-      margin: 0;
-      padding: 0;
-    }
-     
-    .email-masthead {
-      padding: 25px 0;
-      text-align: center;
-    }
-    .email-masthead_logo {
-      max-width: 400px;
-      border: 0;
-    }
-    .email-masthead_name {
-      font-size: 16px;
-      font-weight: bold;
-      color: #2F3133;
-      text-decoration: none;
-      text-shadow: 0 1px 0 white;
-    }
-    .email-logo {
-      max-height: 50px;
-    }
-     
-    .email-body {
-      width: 100%;
-      margin: 0;
-      padding: 0;
-      border-top: 1px solid #EDEFF2;
-      border-bottom: 1px solid #EDEFF2;
-      background-color: #FFF;
-    }
-    .email-body_inner {
-      width: 570px;
-      margin: 0 auto;
-      padding: 0;
-    }
-    .email-footer {
-      width: 570px;
-      margin: 0 auto;
-      padding: 0;
-      text-align: center;
-    }
-    .email-footer p {
-      color: #AEAEAE;
-    }
-    .body-action {
-      width: 100%;
-      margin: 30px auto;
-      padding: 0;
-      text-align: center;
-    }
-    .body-dictionary {
-      width: 100%;
-      overflow: hidden;
-      margin: 20px auto 10px;
-      padding: 0;
-    }
-    .body-dictionary dd {
-      margin: 0 0 10px 0;
-    }
-    .body-dictionary dt {
-      clear: both;
-      color: #000;
-      font-weight: bold;
-    }
-    .body-dictionary dd {
-      margin-left: 0;
-      margin-bottom: 10px;
-    }
-    .body-sub {
-      margin-top: 25px;
-      padding-top: 25px;
-      border-top: 1px solid #EDEFF2;
-      table-layout: fixed;
-    }
-    .body-sub a {
-      word-break: break-all;
-    }
-    .content-cell {
-      padding: 35px;
-    }
-    .align-right {
-      text-align: right;
-    }
-     
-    h1 {
-      margin-top: 0;
-      color: #2F3133;
-      font-size: 19px;
-      font-weight: bold;
-    }
-    h2 {
-      margin-top: 0;
-      color: #2F3133;
-      font-size: 16px;
-      font-weight: bold;
-    }
-    h3 {
-      margin-top: 0;
-      color: #2F3133;
-      font-size: 14px;
-      font-weight: bold;
-    }
-    blockquote {
-      margin: 1.7rem 0;
-      padding-left: 0.85rem;
-      border-left: 10px solid #F0F2F4;
-    }
-    blockquote p {
-        font-size: 1.1rem;
-        color: #999;
-    }
-    blockquote cite {
-        display: block;
-        text-align: right;
-        color: #666;
-        font-size: 1.2rem;
-    }
-    cite {
-      display: block;
-      font-size: 0.925rem; 
-    }
-    cite:before {
-      content: "\2014 \0020";
-    }
-    p {
-      margin-top: 0;
-      color: #74787E;
-      font-size: 16px;
-      line-height: 1.5em;
-    }
-    p.sub {
-      font-size: 12px;
-    }
-    p.center {
-      text-align: center;
-    }
-    table {
-      width: 100%;
-    }
-    th {
-      padding: 0px 5px;
-      padding-bottom: 8px;
-      border-bottom: 1px solid #EDEFF2;
-    }
-    th p {
-      margin: 0;
-      color: #9BA2AB;
-      font-size: 12px;
-    }
-    td {
-      padding: 10px 5px;
-      color: #74787E;
-      font-size: 15px;
-      line-height: 18px;
-    }
-    .content {
-      align: center;
-      padding: 0;
-    }
-     
-    .data-wrapper {
-      width: 100%;
-      margin: 0;
-      padding: 35px 0;
-    }
-    .data-table {
-      width: 100%;
-      margin: 0;
-    }
-    .data-table th {
-      text-align: left;
-      padding: 0px 5px;
-      padding-bottom: 8px;
-      border-bottom: 1px solid #EDEFF2;
-    }
-    .data-table th p {
-      margin: 0;
-      color: #9BA2AB;
-      font-size: 12px;
-    }
-    .data-table td {
-      padding: 10px 5px;
-      color: #74787E;
-      font-size: 15px;
-      line-height: 18px;
-    }
-     
-    .button {
-      display: inline-block;
-      width: 200px;
-      background-color: #3869D4;
-      border-radius: 3px;
-      color: #ffffff;
-      font-size: 15px;
-      line-height: 45px;
-      text-align: center;
-      text-decoration: none;
-      -webkit-text-size-adjust: none;
-      mso-hide: all;
-    }
-     
-    @media only screen and (max-width: 600px) {
-      .email-body_inner,
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><html xmlns="http://www.w3.org/1999/xhtml"><head>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+  
+<style type="text/css">*:not(br):not(tr):not(html) {
+font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif !important;
+-webkit-box-sizing: border-box !important;
+box-sizing: border-box !important
+}cite:before {
+content: "\2014 \0020" !important
+}@media only screen and (max-width: 600px){
+.email-body_inner,
       .email-footer {
-        width: 100% !important;
-      }
-    }
-    @media only screen and (max-width: 500px) {
-      .button {
-        width: 100% !important;
-      }
-    }
-  </style>
-</head>
-<body dir="ltr">
-  <table class="email-wrapper" width="100%" cellpadding="0" cellspacing="0">
-    <tr>
-      <td class="content">
-        <table class="email-content" width="100%" cellpadding="0" cellspacing="0">
+width: 100% !important
+}
+}
+@media only screen and (max-width: 500px){
+.button {
+width: 100% !important
+}
+}
+</style></head>
+<body dir="ltr" style="height:100%;margin:0;line-height:1.4;background-color:#F2F4F6;color:#74787E;-webkit-text-size-adjust:none;width:100%">
+  <table class="email-wrapper" width="100%" cellpadding="0" cellspacing="0" style="width:100%;margin:0;padding:0;background-color:#F2F4F6">
+    <tbody><tr>
+      <td class="content" style="color:#74787E;font-size:15px;line-height:18px;align:center;padding:0">
+        <table class="email-content" width="100%" cellpadding="0" cellspacing="0" style="width:100%;margin:0;padding:0">
           
-          <tr>
-            <td class="email-masthead">
-              <a class="email-masthead_name" href="https://example-hermes.com/" target="_blank">
+          <tbody><tr>
+            <td class="email-masthead" style="color:#74787E;font-size:15px;line-height:18px;padding:25px 0;text-align:center">
+              <a class="email-masthead_name" href="https://example-hermes.com/" target="_blank" style="font-size:16px;font-weight:bold;color:#2F3133;text-decoration:none;text-shadow:0 1px 0 white">
                 
-                  <img src="http://www.duchess-france.org/wp-content/uploads/2016/01/gopher.png" class="email-logo" />
+                  <img src="https://github.com/matcornic/hermes/blob/master/examples/gopher.png?raw=true" class="email-logo" style="max-height:50px"/>
                 
                 </a>
             </td>
@@ -265,16 +38,16 @@
 
           
           <tr>
-            <td class="email-body" width="100%">
-              <table class="email-body_inner" align="center" width="570" cellpadding="0" cellspacing="0">
+            <td class="email-body" width="100%" style="color:#74787E;font-size:15px;line-height:18px;width:100%;margin:0;padding:0;border-top:1px solid #EDEFF2;border-bottom:1px solid #EDEFF2;background-color:#FFF">
+              <table class="email-body_inner" align="center" width="570" cellpadding="0" cellspacing="0" style="width:570px;margin:0 auto;padding:0">
                 
-                <tr>
-                  <td class="content-cell">
-                    <h1>Hi Jon Snow,</h1>
+                <tbody><tr>
+                  <td class="content-cell" style="color:#74787E;font-size:15px;line-height:18px;padding:35px">
+                    <h1 style="margin-top:0;color:#2F3133;font-size:19px;font-weight:bold">Hi Jon Snow,</h1>
                     
                         
                           
-                            <p>You have received this email because a password reset request for Hermes account was received.</p>
+                            <p style="margin-top:0;color:#74787E;font-size:16px;line-height:1.5em">You have received this email because a password reset request for Hermes account was received.</p>
                           
                         
                     
@@ -293,18 +66,36 @@
                       
                         
                           
-                            <p>Click the button below to reset your password:</p>
-                            <table class="body-action" align="center" width="100%" cellpadding="0" cellspacing="0">
-                              <tr>
-                                <td align="center">
+                            <p style="margin-top:0;color:#74787E;font-size:16px;line-height:1.5em">Click the button below to reset your password:</p>
+                            <!--[if mso]>
+                            <div style="margin: 30px auto;v-text-anchor:middle;text-align:center">
+                              <v:roundrect xmlns:v="urn:schemas-microsoft-com:vml" 
+                                xmlns:w="urn:schemas-microsoft-com:office:word" 
+                                href="https://hermes-example.com/reset-password?token=d9729feb74992cc3482b350163a1a010" 
+                                style="height:45px;v-text-anchor:middle;width:300px;background-color:#DC4D2F;"
+                                arcsize="10%" 
+                                strokecolor="#DC4D2F" fillcolor="#DC4D2F"
+                                >
+                                <w:anchorlock/>
+                                <center style="color: #FFFFFF;font-size: 15px;text-align: center;font-family:sans-serif;font-weight:bold;">
+                                  Reset your password
+                                </center>
+                              </v:roundrect>
+                            </div>
+                            <![endif]-->
+                            <!--[if !mso]><!-- -->
+                            <table class="body-action" align="center" width="100%" cellpadding="0" cellspacing="0" style="width:100%;margin:30px auto;padding:0;text-align:center">
+                              <tbody><tr>
+                                <td align="center" style="padding:10px 5px;color:#74787E;font-size:15px;line-height:18px">
                                   <div>
-                                    <a href="https://hermes-example.com/reset-password?token=d9729feb74992cc3482b350163a1a010" class="button" style="background-color: #DC4D2F; " target="_blank">
+                                    <a href="https://hermes-example.com/reset-password?token=d9729feb74992cc3482b350163a1a010" class="button" style="display:inline-block;width:200px;border-radius:3px;font-size:15px;line-height:45px;text-align:center;text-decoration:none;-webkit-text-size-adjust:none;mso-hide:all;color:#ffffff;background-color:#DC4D2F" target="_blank" width="200">
                                       Reset your password
                                     </a>
                                   </div>
                                 </td>
                               </tr>
-                            </table>
+                            </tbody></table>
+                            <!--[endif]---->
                           
                         
                       
@@ -313,26 +104,26 @@
                      
                         
                           
-                            <p>If you did not request a password reset, no further action is required on your part.</p>
+                            <p style="margin-top:0;color:#74787E;font-size:16px;line-height:1.5em">If you did not request a password reset, no further action is required on your part.</p>
                           
                         
                       
 
-                    <p>
+                    <p style="margin-top:0;color:#74787E;font-size:16px;line-height:1.5em">
                       Thanks,
-                      <br />
+                      <br/>
                       Hermes
                     </p>
 
                     
                        
-                        <table class="body-sub">
+                        <table class="body-sub" style="width:100%;margin-top:25px;padding-top:25px;border-top:1px solid #EDEFF2;table-layout:fixed">
                           <tbody>
                               
                                 <tr>
-                                  <td>
-                                    <p class="sub">If you’re having trouble with the button &#39;Reset your password&#39;, copy and paste the URL below into your web browser.</p>
-                                    <p class="sub"><a href="https://hermes-example.com/reset-password?token=d9729feb74992cc3482b350163a1a010">https://hermes-example.com/reset-password?token=d9729feb74992cc3482b350163a1a010</a></p>
+                                  <td style="padding:10px 5px;color:#74787E;font-size:15px;line-height:18px">
+                                    <p class="sub" style="margin-top:0;color:#74787E;line-height:1.5em;font-size:12px">If you’re having trouble with the button &#39;Reset your password&#39;, copy and paste the URL below into your web browser.</p>
+                                    <p class="sub" style="margin-top:0;color:#74787E;line-height:1.5em;font-size:12px"><a href="https://hermes-example.com/reset-password?token=d9729feb74992cc3482b350163a1a010" style="color:#3869D4;word-break:break-all">https://hermes-example.com/reset-password?token=d9729feb74992cc3482b350163a1a010</a></p>
                                   </td>
                                 </tr>
                               
@@ -342,25 +133,26 @@
                     
                   </td>
                 </tr>
-              </table>
+              </tbody></table>
             </td>
           </tr>
           <tr>
-            <td>
-              <table class="email-footer" align="center" width="570" cellpadding="0" cellspacing="0">
-                <tr>
-                  <td class="content-cell">
-                    <p class="sub center">
-                      Copyright © 2019 Hermes. All rights reserved.
+            <td style="padding:10px 5px;color:#74787E;font-size:15px;line-height:18px">
+              <table class="email-footer" align="center" width="570" cellpadding="0" cellspacing="0" style="width:570px;margin:0 auto;padding:0;text-align:center">
+                <tbody><tr>
+                  <td class="content-cell" style="color:#74787E;font-size:15px;line-height:18px;padding:35px">
+                    <p class="sub center" style="margin-top:0;line-height:1.5em;color:#AEAEAE;font-size:12px;text-align:center">
+                      Copyright © 2020 Hermes. All rights reserved.
                     </p>
                   </td>
                 </tr>
-              </table>
+              </tbody></table>
             </td>
           </tr>
-        </table>
+        </tbody></table>
       </td>
     </tr>
-  </table>
-</body>
-</html>
+  </tbody></table>
+
+
+</body></html>

--- a/examples/default/default.reset.html
+++ b/examples/default/default.reset.html
@@ -67,12 +67,15 @@ width: 100% !important
                         
                           
                             <p style="margin-top:0;color:#74787E;font-size:16px;line-height:1.5em">Click the button below to reset your password:</p>
+                            
+                            
+                            
                             <!--[if mso]>
                             <div style="margin: 30px auto;v-text-anchor:middle;text-align:center">
                               <v:roundrect xmlns:v="urn:schemas-microsoft-com:vml" 
                                 xmlns:w="urn:schemas-microsoft-com:office:word" 
                                 href="https://hermes-example.com/reset-password?token=d9729feb74992cc3482b350163a1a010" 
-                                style="height:45px;v-text-anchor:middle;width:300px;background-color:#DC4D2F;"
+                                style="height:45px;v-text-anchor:middle;width:200px;background-color:#DC4D2F;"
                                 arcsize="10%" 
                                 strokecolor="#DC4D2F" fillcolor="#DC4D2F"
                                 >
@@ -88,7 +91,7 @@ width: 100% !important
                               <tbody><tr>
                                 <td align="center" style="padding:10px 5px;color:#74787E;font-size:15px;line-height:18px">
                                   <div>
-                                    <a href="https://hermes-example.com/reset-password?token=d9729feb74992cc3482b350163a1a010" class="button" style="display:inline-block;width:200px;border-radius:3px;font-size:15px;line-height:45px;text-align:center;text-decoration:none;-webkit-text-size-adjust:none;mso-hide:all;color:#ffffff;background-color:#DC4D2F" target="_blank" width="200">
+                                    <a href="https://hermes-example.com/reset-password?token=d9729feb74992cc3482b350163a1a010" class="button" style="display:inline-block;border-radius:3px;font-size:15px;line-height:45px;text-align:center;text-decoration:none;-webkit-text-size-adjust:none;mso-hide:all;color:#ffffff;background-color:#DC4D2F;width:200px" target="_blank" width="200">
                                       Reset your password
                                     </a>
                                   </div>

--- a/examples/default/default.reset.txt
+++ b/examples/default/default.reset.txt
@@ -11,4 +11,4 @@ If you did not request a password reset, no further action is required on your p
 Thanks,
 Hermes - https://example-hermes.com/
 
-Copyright © 2019 Hermes. All rights reserved.
+Copyright © 2020 Hermes. All rights reserved.

--- a/examples/default/default.welcome.html
+++ b/examples/default/default.welcome.html
@@ -1,263 +1,36 @@
-
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-  <style type="text/css" rel="stylesheet" media="all">
-     
-    *:not(br):not(tr):not(html) {
-      font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif;
-      -webkit-box-sizing: border-box;
-      box-sizing: border-box;
-    }
-    body {
-      width: 100% !important;
-      height: 100%;
-      margin: 0;
-      line-height: 1.4;
-      background-color: #F2F4F6;
-      color: #74787E;
-      -webkit-text-size-adjust: none;
-    }
-    a {
-      color: #3869D4;
-    }
-     
-    .email-wrapper {
-      width: 100%;
-      margin: 0;
-      padding: 0;
-      background-color: #F2F4F6;
-    }
-    .email-content {
-      width: 100%;
-      margin: 0;
-      padding: 0;
-    }
-     
-    .email-masthead {
-      padding: 25px 0;
-      text-align: center;
-    }
-    .email-masthead_logo {
-      max-width: 400px;
-      border: 0;
-    }
-    .email-masthead_name {
-      font-size: 16px;
-      font-weight: bold;
-      color: #2F3133;
-      text-decoration: none;
-      text-shadow: 0 1px 0 white;
-    }
-    .email-logo {
-      max-height: 50px;
-    }
-     
-    .email-body {
-      width: 100%;
-      margin: 0;
-      padding: 0;
-      border-top: 1px solid #EDEFF2;
-      border-bottom: 1px solid #EDEFF2;
-      background-color: #FFF;
-    }
-    .email-body_inner {
-      width: 570px;
-      margin: 0 auto;
-      padding: 0;
-    }
-    .email-footer {
-      width: 570px;
-      margin: 0 auto;
-      padding: 0;
-      text-align: center;
-    }
-    .email-footer p {
-      color: #AEAEAE;
-    }
-    .body-action {
-      width: 100%;
-      margin: 30px auto;
-      padding: 0;
-      text-align: center;
-    }
-    .body-dictionary {
-      width: 100%;
-      overflow: hidden;
-      margin: 20px auto 10px;
-      padding: 0;
-    }
-    .body-dictionary dd {
-      margin: 0 0 10px 0;
-    }
-    .body-dictionary dt {
-      clear: both;
-      color: #000;
-      font-weight: bold;
-    }
-    .body-dictionary dd {
-      margin-left: 0;
-      margin-bottom: 10px;
-    }
-    .body-sub {
-      margin-top: 25px;
-      padding-top: 25px;
-      border-top: 1px solid #EDEFF2;
-      table-layout: fixed;
-    }
-    .body-sub a {
-      word-break: break-all;
-    }
-    .content-cell {
-      padding: 35px;
-    }
-    .align-right {
-      text-align: right;
-    }
-     
-    h1 {
-      margin-top: 0;
-      color: #2F3133;
-      font-size: 19px;
-      font-weight: bold;
-    }
-    h2 {
-      margin-top: 0;
-      color: #2F3133;
-      font-size: 16px;
-      font-weight: bold;
-    }
-    h3 {
-      margin-top: 0;
-      color: #2F3133;
-      font-size: 14px;
-      font-weight: bold;
-    }
-    blockquote {
-      margin: 1.7rem 0;
-      padding-left: 0.85rem;
-      border-left: 10px solid #F0F2F4;
-    }
-    blockquote p {
-        font-size: 1.1rem;
-        color: #999;
-    }
-    blockquote cite {
-        display: block;
-        text-align: right;
-        color: #666;
-        font-size: 1.2rem;
-    }
-    cite {
-      display: block;
-      font-size: 0.925rem; 
-    }
-    cite:before {
-      content: "\2014 \0020";
-    }
-    p {
-      margin-top: 0;
-      color: #74787E;
-      font-size: 16px;
-      line-height: 1.5em;
-    }
-    p.sub {
-      font-size: 12px;
-    }
-    p.center {
-      text-align: center;
-    }
-    table {
-      width: 100%;
-    }
-    th {
-      padding: 0px 5px;
-      padding-bottom: 8px;
-      border-bottom: 1px solid #EDEFF2;
-    }
-    th p {
-      margin: 0;
-      color: #9BA2AB;
-      font-size: 12px;
-    }
-    td {
-      padding: 10px 5px;
-      color: #74787E;
-      font-size: 15px;
-      line-height: 18px;
-    }
-    .content {
-      align: center;
-      padding: 0;
-    }
-     
-    .data-wrapper {
-      width: 100%;
-      margin: 0;
-      padding: 35px 0;
-    }
-    .data-table {
-      width: 100%;
-      margin: 0;
-    }
-    .data-table th {
-      text-align: left;
-      padding: 0px 5px;
-      padding-bottom: 8px;
-      border-bottom: 1px solid #EDEFF2;
-    }
-    .data-table th p {
-      margin: 0;
-      color: #9BA2AB;
-      font-size: 12px;
-    }
-    .data-table td {
-      padding: 10px 5px;
-      color: #74787E;
-      font-size: 15px;
-      line-height: 18px;
-    }
-     
-    .button {
-      display: inline-block;
-      width: 200px;
-      background-color: #3869D4;
-      border-radius: 3px;
-      color: #ffffff;
-      font-size: 15px;
-      line-height: 45px;
-      text-align: center;
-      text-decoration: none;
-      -webkit-text-size-adjust: none;
-      mso-hide: all;
-    }
-     
-    @media only screen and (max-width: 600px) {
-      .email-body_inner,
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><html xmlns="http://www.w3.org/1999/xhtml"><head>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+  
+<style type="text/css">*:not(br):not(tr):not(html) {
+font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif !important;
+-webkit-box-sizing: border-box !important;
+box-sizing: border-box !important
+}cite:before {
+content: "\2014 \0020" !important
+}@media only screen and (max-width: 600px){
+.email-body_inner,
       .email-footer {
-        width: 100% !important;
-      }
-    }
-    @media only screen and (max-width: 500px) {
-      .button {
-        width: 100% !important;
-      }
-    }
-  </style>
-</head>
-<body dir="ltr">
-  <table class="email-wrapper" width="100%" cellpadding="0" cellspacing="0">
-    <tr>
-      <td class="content">
-        <table class="email-content" width="100%" cellpadding="0" cellspacing="0">
+width: 100% !important
+}
+}
+@media only screen and (max-width: 500px){
+.button {
+width: 100% !important
+}
+}
+</style></head>
+<body dir="ltr" style="height:100%;margin:0;line-height:1.4;background-color:#F2F4F6;color:#74787E;-webkit-text-size-adjust:none;width:100%">
+  <table class="email-wrapper" width="100%" cellpadding="0" cellspacing="0" style="width:100%;margin:0;padding:0;background-color:#F2F4F6">
+    <tbody><tr>
+      <td class="content" style="color:#74787E;font-size:15px;line-height:18px;align:center;padding:0">
+        <table class="email-content" width="100%" cellpadding="0" cellspacing="0" style="width:100%;margin:0;padding:0">
           
-          <tr>
-            <td class="email-masthead">
-              <a class="email-masthead_name" href="https://example-hermes.com/" target="_blank">
+          <tbody><tr>
+            <td class="email-masthead" style="color:#74787E;font-size:15px;line-height:18px;padding:25px 0;text-align:center">
+              <a class="email-masthead_name" href="https://example-hermes.com/" target="_blank" style="font-size:16px;font-weight:bold;color:#2F3133;text-decoration:none;text-shadow:0 1px 0 white">
                 
-                  <img src="http://www.duchess-france.org/wp-content/uploads/2016/01/gopher.png" class="email-logo" />
+                  <img src="https://github.com/matcornic/hermes/blob/master/examples/gopher.png?raw=true" class="email-logo" style="max-height:50px"/>
                 
                 </a>
             </td>
@@ -265,16 +38,16 @@
 
           
           <tr>
-            <td class="email-body" width="100%">
-              <table class="email-body_inner" align="center" width="570" cellpadding="0" cellspacing="0">
+            <td class="email-body" width="100%" style="color:#74787E;font-size:15px;line-height:18px;width:100%;margin:0;padding:0;border-top:1px solid #EDEFF2;border-bottom:1px solid #EDEFF2;background-color:#FFF">
+              <table class="email-body_inner" align="center" width="570" cellpadding="0" cellspacing="0" style="width:570px;margin:0 auto;padding:0">
                 
-                <tr>
-                  <td class="content-cell">
-                    <h1>Hi Jon Snow,</h1>
+                <tbody><tr>
+                  <td class="content-cell" style="color:#74787E;font-size:15px;line-height:18px;padding:35px">
+                    <h1 style="margin-top:0;color:#2F3133;font-size:19px;font-weight:bold">Hi Jon Snow,</h1>
                     
                         
                           
-                            <p>Welcome to Hermes! We&#39;re very excited to have you on board.</p>
+                            <p style="margin-top:0;color:#74787E;font-size:16px;line-height:1.5em">Welcome to Hermes! We&#39;re very excited to have you on board.</p>
                           
                         
                     
@@ -282,16 +55,16 @@
 
                        
                         
-                          <dl class="body-dictionary">
+                          <dl class="body-dictionary" style="width:100%;overflow:hidden;margin:20px auto 10px;padding:0">
                             
-                              <dt>Firstname:</dt>
-                              <dd>Jon</dd>
+                              <dt style="clear:both;color:#000;font-weight:bold">Firstname:</dt>
+                              <dd style="margin:0 0 10px 0;margin-left:0;margin-bottom:10px">Jon</dd>
                             
-                              <dt>Lastname:</dt>
-                              <dd>Snow</dd>
+                              <dt style="clear:both;color:#000;font-weight:bold">Lastname:</dt>
+                              <dd style="margin:0 0 10px 0;margin-left:0;margin-bottom:10px">Snow</dd>
                             
-                              <dt>Birthday:</dt>
-                              <dd>01/01/283</dd>
+                              <dt style="clear:both;color:#000;font-weight:bold">Birthday:</dt>
+                              <dd style="margin:0 0 10px 0;margin-left:0;margin-bottom:10px">01/01/283</dd>
                             
                           </dl>
                         
@@ -308,18 +81,36 @@
                       
                         
                           
-                            <p>To get started with Hermes, please click here:</p>
-                            <table class="body-action" align="center" width="100%" cellpadding="0" cellspacing="0">
-                              <tr>
-                                <td align="center">
+                            <p style="margin-top:0;color:#74787E;font-size:16px;line-height:1.5em">To get started with Hermes, please click here:</p>
+                            <!--[if mso]>
+                            <div style="margin: 30px auto;v-text-anchor:middle;text-align:center">
+                              <v:roundrect xmlns:v="urn:schemas-microsoft-com:vml" 
+                                xmlns:w="urn:schemas-microsoft-com:office:word" 
+                                href="https://hermes-example.com/confirm?token=d9729feb74992cc3482b350163a1a010" 
+                                style="height:45px;v-text-anchor:middle;width:300px;background-color:#3869D4;"
+                                arcsize="10%" 
+                                strokecolor="#3869D4" fillcolor="#3869D4"
+                                >
+                                <w:anchorlock/>
+                                <center style="color: #FFFFFF;font-size: 15px;text-align: center;font-family:sans-serif;font-weight:bold;">
+                                  Confirm your account
+                                </center>
+                              </v:roundrect>
+                            </div>
+                            <![endif]-->
+                            <!--[if !mso]><!-- -->
+                            <table class="body-action" align="center" width="100%" cellpadding="0" cellspacing="0" style="width:100%;margin:30px auto;padding:0;text-align:center">
+                              <tbody><tr>
+                                <td align="center" style="padding:10px 5px;color:#74787E;font-size:15px;line-height:18px">
                                   <div>
-                                    <a href="https://hermes-example.com/confirm?token=d9729feb74992cc3482b350163a1a010" class="button" style=" " target="_blank">
+                                    <a href="https://hermes-example.com/confirm?token=d9729feb74992cc3482b350163a1a010" class="button" style="display:inline-block;width:200px;background-color:#3869D4;border-radius:3px;font-size:15px;line-height:45px;text-align:center;text-decoration:none;-webkit-text-size-adjust:none;mso-hide:all;color:#ffffff" target="_blank" width="200">
                                       Confirm your account
                                     </a>
                                   </div>
                                 </td>
                               </tr>
-                            </table>
+                            </tbody></table>
+                            <!--[endif]---->
                           
                         
                       
@@ -328,26 +119,26 @@
                      
                         
                           
-                            <p>Need help, or have questions? Just reply to this email, we&#39;d love to help.</p>
+                            <p style="margin-top:0;color:#74787E;font-size:16px;line-height:1.5em">Need help, or have questions? Just reply to this email, we&#39;d love to help.</p>
                           
                         
                       
 
-                    <p>
+                    <p style="margin-top:0;color:#74787E;font-size:16px;line-height:1.5em">
                       Yours truly,
-                      <br />
+                      <br/>
                       Hermes
                     </p>
 
                     
                        
-                        <table class="body-sub">
+                        <table class="body-sub" style="width:100%;margin-top:25px;padding-top:25px;border-top:1px solid #EDEFF2;table-layout:fixed">
                           <tbody>
                               
                                 <tr>
-                                  <td>
-                                    <p class="sub">If you’re having trouble with the button &#39;Confirm your account&#39;, copy and paste the URL below into your web browser.</p>
-                                    <p class="sub"><a href="https://hermes-example.com/confirm?token=d9729feb74992cc3482b350163a1a010">https://hermes-example.com/confirm?token=d9729feb74992cc3482b350163a1a010</a></p>
+                                  <td style="padding:10px 5px;color:#74787E;font-size:15px;line-height:18px">
+                                    <p class="sub" style="margin-top:0;color:#74787E;line-height:1.5em;font-size:12px">If you’re having trouble with the button &#39;Confirm your account&#39;, copy and paste the URL below into your web browser.</p>
+                                    <p class="sub" style="margin-top:0;color:#74787E;line-height:1.5em;font-size:12px"><a href="https://hermes-example.com/confirm?token=d9729feb74992cc3482b350163a1a010" style="color:#3869D4;word-break:break-all">https://hermes-example.com/confirm?token=d9729feb74992cc3482b350163a1a010</a></p>
                                   </td>
                                 </tr>
                               
@@ -357,25 +148,26 @@
                     
                   </td>
                 </tr>
-              </table>
+              </tbody></table>
             </td>
           </tr>
           <tr>
-            <td>
-              <table class="email-footer" align="center" width="570" cellpadding="0" cellspacing="0">
-                <tr>
-                  <td class="content-cell">
-                    <p class="sub center">
-                      Copyright © 2019 Hermes. All rights reserved.
+            <td style="padding:10px 5px;color:#74787E;font-size:15px;line-height:18px">
+              <table class="email-footer" align="center" width="570" cellpadding="0" cellspacing="0" style="width:570px;margin:0 auto;padding:0;text-align:center">
+                <tbody><tr>
+                  <td class="content-cell" style="color:#74787E;font-size:15px;line-height:18px;padding:35px">
+                    <p class="sub center" style="margin-top:0;line-height:1.5em;color:#AEAEAE;font-size:12px;text-align:center">
+                      Copyright © 2020 Hermes. All rights reserved.
                     </p>
                   </td>
                 </tr>
-              </table>
+              </tbody></table>
             </td>
           </tr>
-        </table>
+        </tbody></table>
       </td>
     </tr>
-  </table>
-</body>
-</html>
+  </tbody></table>
+
+
+</body></html>

--- a/examples/default/default.welcome.html
+++ b/examples/default/default.welcome.html
@@ -82,12 +82,15 @@ width: 100% !important
                         
                           
                             <p style="margin-top:0;color:#74787E;font-size:16px;line-height:1.5em">To get started with Hermes, please click here:</p>
+                            
+                            
+                            
                             <!--[if mso]>
                             <div style="margin: 30px auto;v-text-anchor:middle;text-align:center">
                               <v:roundrect xmlns:v="urn:schemas-microsoft-com:vml" 
                                 xmlns:w="urn:schemas-microsoft-com:office:word" 
                                 href="https://hermes-example.com/confirm?token=d9729feb74992cc3482b350163a1a010" 
-                                style="height:45px;v-text-anchor:middle;width:300px;background-color:#3869D4;"
+                                style="height:45px;v-text-anchor:middle;width:200px;background-color:#3869D4;"
                                 arcsize="10%" 
                                 strokecolor="#3869D4" fillcolor="#3869D4"
                                 >
@@ -103,7 +106,7 @@ width: 100% !important
                               <tbody><tr>
                                 <td align="center" style="padding:10px 5px;color:#74787E;font-size:15px;line-height:18px">
                                   <div>
-                                    <a href="https://hermes-example.com/confirm?token=d9729feb74992cc3482b350163a1a010" class="button" style="display:inline-block;width:200px;background-color:#3869D4;border-radius:3px;font-size:15px;line-height:45px;text-align:center;text-decoration:none;-webkit-text-size-adjust:none;mso-hide:all;color:#ffffff" target="_blank" width="200">
+                                    <a href="https://hermes-example.com/confirm?token=d9729feb74992cc3482b350163a1a010" class="button" style="display:inline-block;background-color:#3869D4;border-radius:3px;font-size:15px;line-height:45px;text-align:center;text-decoration:none;-webkit-text-size-adjust:none;mso-hide:all;color:#ffffff;width:200px" target="_blank" width="200">
                                       Confirm your account
                                     </a>
                                   </div>

--- a/examples/default/default.welcome.txt
+++ b/examples/default/default.welcome.txt
@@ -15,4 +15,4 @@ Need help, or have questions? Just reply to this email, we'd love to help.
 Yours truly,
 Hermes - https://example-hermes.com/
 
-Copyright © 2019 Hermes. All rights reserved.
+Copyright © 2020 Hermes. All rights reserved.

--- a/examples/flat/flat.maintenance.html
+++ b/examples/flat/flat.maintenance.html
@@ -1,263 +1,31 @@
-
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-  <style type="text/css" rel="stylesheet" media="all">
-     
-    *:not(br):not(tr):not(html) {
-      font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif;
-      -webkit-box-sizing: border-box;
-      box-sizing: border-box;
-    }
-    body {
-      width: 100% !important;
-      height: 100%;
-      margin: 0;
-      line-height: 1.4;
-      background-color: #2c3e50;
-      color: #74787E;
-      -webkit-text-size-adjust: none;
-    }
-    a {
-      color: #3869D4;
-    }
-
-     
-    .email-wrapper {
-      width: 100%;
-      margin: 0;
-      padding: 0;
-      background-color: #2c3e50;
-    }
-    .email-content {
-      width: 100%;
-      margin: 0;
-      padding: 0;
-    }
-     
-    .email-masthead {
-      padding: 25px 0;
-      text-align: center;
-    }
-    .email-masthead_logo {
-      max-width: 400px;
-      border: 0;
-    }
-    .email-masthead_name {
-      font-size: 16px;
-      font-weight: bold;
-      color: #2F3133;
-      text-decoration: none;
-      text-shadow: 0 1px 0 white;
-    }
-    .email-logo {
-      max-height: 50px;
-    }
-     
-    .email-body {
-      width: 100%;
-      margin: 0;
-      padding: 0;
-      border-top: 1px solid #EDEFF2;
-      border-bottom: 1px solid #EDEFF2;
-      background-color: #FFF;
-    }
-    .email-body_inner {
-      width: 570px;
-      margin: 0 auto;
-      padding: 0;
-    }
-    .email-footer {
-      width: 570px;
-      margin: 0 auto;
-      padding: 0;
-      text-align: center;
-    }
-    .email-footer p {
-      color: #eaeaea;
-    }
-    .body-action {
-      width: 100%;
-      margin: 30px auto;
-      padding: 0;
-      text-align: center;
-    }
-
-    .body-dictionary {
-      width: 100%;
-      overflow: hidden;
-      margin: 20px auto 20px;
-      padding: 0;
-    }
-    .body-dictionary dt {
-      clear: both;
-      color: #000;
-      font-weight: bold;
-      float: left;
-      width: 50%;
-      padding: 0;
-      margin: 0;
-      margin-bottom: 0.3em;
-    }
-    .body-dictionary dd {
-      float: left;
-      width: 50%;
-      padding: 0;
-      margin: 0;
-    }
-    .body-sub {
-      margin-top: 25px;
-      padding-top: 25px;
-      border-top: 1px solid #EDEFF2;
-      table-layout: fixed;
-    }
-    .body-sub a {
-      word-break: break-all;
-    }
-    .content-cell {
-      padding: 35px;
-    }
-    .align-right {
-      text-align: right;
-    }
-     
-    h1 {
-      margin-top: 0;
-      color: #2F3133;
-      font-size: 19px;
-      font-weight: bold;
-    }
-    h2 {
-      margin-top: 0;
-      color: #2F3133;
-      font-size: 16px;
-      font-weight: bold;
-    }
-    h3 {
-      margin-top: 0;
-      color: #2F3133;
-      font-size: 14px;
-      font-weight: bold;
-    }
-    blockquote {
-      margin: 1.7rem 0;
-      padding-left: 0.85rem;
-      border-left: 10px solid #F0F2F4;
-    }
-    blockquote p {
-        font-size: 1.1rem;
-        color: #999;
-    }
-    blockquote cite {
-        display: block;
-        text-align: right;
-        color: #666;
-        font-size: 1.2rem;
-    }
-    cite {
-      display: block;
-      font-size: 0.925rem; 
-    }
-    cite:before {
-      content: "\2014 \0020";
-    }
-    p {
-      margin-top: 0;
-      color: #74787E;
-      font-size: 16px;
-      line-height: 1.5em;
-    }
-    p.sub {
-      font-size: 12px;
-    }
-    p.center {
-      text-align: center;
-    }
-    table {
-      width: 100%;
-    }
-    th {
-      padding: 0px 5px;
-      padding-bottom: 8px;
-      border-bottom: 1px solid #EDEFF2;
-    }
-    th p {
-      margin: 0;
-      color: #9BA2AB;
-      font-size: 12px;
-    }
-    td {
-      padding: 10px 5px;
-      color: #74787E;
-      font-size: 15px;
-      line-height: 18px;
-    }
-    .content {
-      align: center;
-      padding: 0;
-    }
-     
-    .data-wrapper {
-      width: 100%;
-      margin: 0;
-      padding: 35px 0;
-    }
-    .data-table {
-      width: 100%;
-      margin: 0;
-    }
-    .data-table th {
-      text-align: left;
-      padding: 0px 5px;
-      padding-bottom: 8px;
-      border-bottom: 1px solid #EDEFF2;
-    }
-    .data-table th p {
-      margin: 0;
-      color: #9BA2AB;
-      font-size: 12px;
-    }
-    .data-table td {
-      padding: 10px 5px;
-      color: #74787E;
-      font-size: 15px;
-      line-height: 18px;
-    }
-     
-    .button {
-      display: inline-block;
-      width: 100%;
-      background-color: #00948d;
-      color: #ffffff;
-      font-size: 15px;
-      line-height: 45px;
-      text-align: center;
-      text-decoration: none;
-      -webkit-text-size-adjust: none;
-      mso-hide: all;
-    }
-     
-    @media only screen and (max-width: 600px) {
-      .email-body_inner,
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><html xmlns="http://www.w3.org/1999/xhtml"><head>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+  
+<style type="text/css">*:not(br):not(tr):not(html) {
+font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif !important;
+-webkit-box-sizing: border-box !important;
+box-sizing: border-box !important
+}cite:before {
+content: "\2014 \0020" !important
+}@media only screen and (max-width: 600px){
+.email-body_inner,
       .email-footer {
-        width: 100% !important;
-      }
-    }
-  </style>
-</head>
-<body dir="ltr">
-  <table class="email-wrapper" width="100%" cellpadding="0" cellspacing="0">
-    <tr>
-      <td class="content">
-        <table class="email-content" width="100%" cellpadding="0" cellspacing="0">
+width: 100% !important
+}
+}
+</style></head>
+<body dir="ltr" style="height:100%;margin:0;line-height:1.4;background-color:#2c3e50;color:#74787E;-webkit-text-size-adjust:none;width:100%">
+  <table class="email-wrapper" width="100%" cellpadding="0" cellspacing="0" style="width:100%;margin:0;padding:0;background-color:#2c3e50">
+    <tbody><tr>
+      <td class="content" style="color:#74787E;font-size:15px;line-height:18px;align:center;padding:0">
+        <table class="email-content" width="100%" cellpadding="0" cellspacing="0" style="width:100%;margin:0;padding:0">
           
-          <tr>
-            <td class="email-masthead">
-              <a class="email-masthead_name" href="https://example-hermes.com/" target="_blank">
+          <tbody><tr>
+            <td class="email-masthead" style="color:#74787E;font-size:15px;line-height:18px;padding:25px 0;text-align:center">
+              <a class="email-masthead_name" href="https://example-hermes.com/" target="_blank" style="font-size:16px;font-weight:bold;color:#2F3133;text-decoration:none;text-shadow:0 1px 0 white">
                 
-                  <img src="http://www.duchess-france.org/wp-content/uploads/2016/01/gopher.png" class="email-logo" />
+                  <img src="https://github.com/matcornic/hermes/blob/master/examples/gopher.png?raw=true" class="email-logo" style="max-height:50px"/>
                 
                 </a>
             </td>
@@ -265,81 +33,79 @@
 
           
           <tr>
-            <td class="email-body" width="100%">
-              <table class="email-body_inner" align="center" width="570" cellpadding="0" cellspacing="0">
+            <td class="email-body" width="100%" style="color:#74787E;font-size:15px;line-height:18px;width:100%;margin:0;padding:0;border-top:1px solid #EDEFF2;border-bottom:1px solid #EDEFF2;background-color:#FFF">
+              <table class="email-body_inner" align="center" width="570" cellpadding="0" cellspacing="0" style="width:570px;margin:0 auto;padding:0">
                 
-                <tr>
-                  <td class="content-cell">
-                    <h1>Hi Jon Snow,</h1>
+                <tbody><tr>
+                  <td class="content-cell" style="color:#74787E;font-size:15px;line-height:18px;padding:35px">
+                    <h1 style="margin-top:0;color:#2F3133;font-size:19px;font-weight:bold">Hi Jon Snow,</h1>
                     
                     
-                      <blockquote>
-<p><em>Hermes</em> service will shutdown the <strong>1st August 2017</strong> for maintenance operations.</p>
+                      <blockquote style="margin:25px 0;padding-left:10px;border-left:10px solid #F0F2F4">
+<p style="margin-top:0;line-height:1.5em;font-size:1.1rem;color:#999"><em>Hermes</em> service will shutdown the <strong>1st August 2017</strong> for maintenance operations.</p>
 </blockquote>
 
-<p>Services will be unavailable based on the following schedule:</p>
+<p style="margin-top:0;color:#74787E;font-size:16px;line-height:1.5em">Services will be unavailable based on the following schedule:</p>
 
-<table>
+<table style="width:100%">
 <thead>
 <tr>
-<th align="center">Services</th>
-<th align="center">Downtime</th>
+<th align="center" style="padding:0px 5px;padding-bottom:8px;border-bottom:1px solid #EDEFF2">Services</th>
+<th align="center" style="padding:0px 5px;padding-bottom:8px;border-bottom:1px solid #EDEFF2">Downtime</th>
 </tr>
 </thead>
 
 <tbody>
 <tr>
-<td align="center">Service A</td>
-<td align="center">2AM to 3AM</td>
+<td align="center" style="padding:10px 5px;color:#74787E;font-size:15px;line-height:18px">Service A</td>
+<td align="center" style="padding:10px 5px;color:#74787E;font-size:15px;line-height:18px">2AM to 3AM</td>
 </tr>
 
 <tr>
-<td align="center">Service B</td>
-<td align="center">4AM to 5AM</td>
+<td align="center" style="padding:10px 5px;color:#74787E;font-size:15px;line-height:18px">Service B</td>
+<td align="center" style="padding:10px 5px;color:#74787E;font-size:15px;line-height:18px">4AM to 5AM</td>
 </tr>
 
 <tr>
-<td align="center">Service C</td>
-<td align="center">5AM to 6AM</td>
+<td align="center" style="padding:10px 5px;color:#74787E;font-size:15px;line-height:18px">Service C</td>
+<td align="center" style="padding:10px 5px;color:#74787E;font-size:15px;line-height:18px">5AM to 6AM</td>
 </tr>
 </tbody>
 </table>
-
-<hr />
-
-<p>Feel free to contact us for any question regarding this matter at <a href="mailto:support@hermes-example.com">support@hermes-example.com</a> or in our <a href="https://gitter.im/">Gitter</a></p>
+<p style="margin-top:0;color:#74787E;font-size:16px;line-height:1.5em">Feel free to contact us for any question regarding this matter at <a href="mailto:support@hermes-example.com" style="color:#3869D4">support@hermes-example.com</a> or in our <a href="https://gitter.im/" style="color:#3869D4">Gitter</a></p>
 
                     
                     
 
-                    <p>
+                    <p style="margin-top:0;color:#74787E;font-size:16px;line-height:1.5em">
                       Yours truly,
-                      <br />
+                      <br/>
                       Hermes
                     </p>
 
                     
                   </td>
                 </tr>
-              </table>
+              </tbody></table>
             </td>
           </tr>
           <tr>
-            <td>
-              <table class="email-footer" align="center" width="570" cellpadding="0" cellspacing="0">
-                <tr>
-                  <td class="content-cell">
-                    <p class="sub center">
-                      Copyright © 2019 Hermes. All rights reserved.
+            <td style="padding:10px 5px;color:#74787E;font-size:15px;line-height:18px">
+              <table class="email-footer" align="center" width="570" cellpadding="0" cellspacing="0" style="width:570px;margin:0 auto;padding:0;text-align:center">
+                <tbody><tr>
+                  <td class="content-cell" style="color:#74787E;font-size:15px;line-height:18px;padding:35px">
+                    <p class="sub center" style="margin-top:0;line-height:1.5em;color:#eaeaea;font-size:12px;text-align:center">
+                      Copyright © 2020 Hermes. All rights reserved.
                     </p>
                   </td>
                 </tr>
-              </table>
+              </tbody></table>
             </td>
           </tr>
-        </table>
+        </tbody></table>
       </td>
     </tr>
-  </table>
-</body>
-</html>
+  </tbody></table>
+
+
+</body></html>

--- a/examples/flat/flat.maintenance.txt
+++ b/examples/flat/flat.maintenance.txt
@@ -25,4 +25,4 @@ Feel free to contact us for any question regarding this matter at support@hermes
 Yours truly,
 Hermes - https://example-hermes.com/
 
-Copyright © 2019 Hermes. All rights reserved.
+Copyright © 2020 Hermes. All rights reserved.

--- a/examples/flat/flat.receipt.html
+++ b/examples/flat/flat.receipt.html
@@ -1,263 +1,31 @@
-
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-  <style type="text/css" rel="stylesheet" media="all">
-     
-    *:not(br):not(tr):not(html) {
-      font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif;
-      -webkit-box-sizing: border-box;
-      box-sizing: border-box;
-    }
-    body {
-      width: 100% !important;
-      height: 100%;
-      margin: 0;
-      line-height: 1.4;
-      background-color: #2c3e50;
-      color: #74787E;
-      -webkit-text-size-adjust: none;
-    }
-    a {
-      color: #3869D4;
-    }
-
-     
-    .email-wrapper {
-      width: 100%;
-      margin: 0;
-      padding: 0;
-      background-color: #2c3e50;
-    }
-    .email-content {
-      width: 100%;
-      margin: 0;
-      padding: 0;
-    }
-     
-    .email-masthead {
-      padding: 25px 0;
-      text-align: center;
-    }
-    .email-masthead_logo {
-      max-width: 400px;
-      border: 0;
-    }
-    .email-masthead_name {
-      font-size: 16px;
-      font-weight: bold;
-      color: #2F3133;
-      text-decoration: none;
-      text-shadow: 0 1px 0 white;
-    }
-    .email-logo {
-      max-height: 50px;
-    }
-     
-    .email-body {
-      width: 100%;
-      margin: 0;
-      padding: 0;
-      border-top: 1px solid #EDEFF2;
-      border-bottom: 1px solid #EDEFF2;
-      background-color: #FFF;
-    }
-    .email-body_inner {
-      width: 570px;
-      margin: 0 auto;
-      padding: 0;
-    }
-    .email-footer {
-      width: 570px;
-      margin: 0 auto;
-      padding: 0;
-      text-align: center;
-    }
-    .email-footer p {
-      color: #eaeaea;
-    }
-    .body-action {
-      width: 100%;
-      margin: 30px auto;
-      padding: 0;
-      text-align: center;
-    }
-
-    .body-dictionary {
-      width: 100%;
-      overflow: hidden;
-      margin: 20px auto 20px;
-      padding: 0;
-    }
-    .body-dictionary dt {
-      clear: both;
-      color: #000;
-      font-weight: bold;
-      float: left;
-      width: 50%;
-      padding: 0;
-      margin: 0;
-      margin-bottom: 0.3em;
-    }
-    .body-dictionary dd {
-      float: left;
-      width: 50%;
-      padding: 0;
-      margin: 0;
-    }
-    .body-sub {
-      margin-top: 25px;
-      padding-top: 25px;
-      border-top: 1px solid #EDEFF2;
-      table-layout: fixed;
-    }
-    .body-sub a {
-      word-break: break-all;
-    }
-    .content-cell {
-      padding: 35px;
-    }
-    .align-right {
-      text-align: right;
-    }
-     
-    h1 {
-      margin-top: 0;
-      color: #2F3133;
-      font-size: 19px;
-      font-weight: bold;
-    }
-    h2 {
-      margin-top: 0;
-      color: #2F3133;
-      font-size: 16px;
-      font-weight: bold;
-    }
-    h3 {
-      margin-top: 0;
-      color: #2F3133;
-      font-size: 14px;
-      font-weight: bold;
-    }
-    blockquote {
-      margin: 1.7rem 0;
-      padding-left: 0.85rem;
-      border-left: 10px solid #F0F2F4;
-    }
-    blockquote p {
-        font-size: 1.1rem;
-        color: #999;
-    }
-    blockquote cite {
-        display: block;
-        text-align: right;
-        color: #666;
-        font-size: 1.2rem;
-    }
-    cite {
-      display: block;
-      font-size: 0.925rem; 
-    }
-    cite:before {
-      content: "\2014 \0020";
-    }
-    p {
-      margin-top: 0;
-      color: #74787E;
-      font-size: 16px;
-      line-height: 1.5em;
-    }
-    p.sub {
-      font-size: 12px;
-    }
-    p.center {
-      text-align: center;
-    }
-    table {
-      width: 100%;
-    }
-    th {
-      padding: 0px 5px;
-      padding-bottom: 8px;
-      border-bottom: 1px solid #EDEFF2;
-    }
-    th p {
-      margin: 0;
-      color: #9BA2AB;
-      font-size: 12px;
-    }
-    td {
-      padding: 10px 5px;
-      color: #74787E;
-      font-size: 15px;
-      line-height: 18px;
-    }
-    .content {
-      align: center;
-      padding: 0;
-    }
-     
-    .data-wrapper {
-      width: 100%;
-      margin: 0;
-      padding: 35px 0;
-    }
-    .data-table {
-      width: 100%;
-      margin: 0;
-    }
-    .data-table th {
-      text-align: left;
-      padding: 0px 5px;
-      padding-bottom: 8px;
-      border-bottom: 1px solid #EDEFF2;
-    }
-    .data-table th p {
-      margin: 0;
-      color: #9BA2AB;
-      font-size: 12px;
-    }
-    .data-table td {
-      padding: 10px 5px;
-      color: #74787E;
-      font-size: 15px;
-      line-height: 18px;
-    }
-     
-    .button {
-      display: inline-block;
-      width: 100%;
-      background-color: #00948d;
-      color: #ffffff;
-      font-size: 15px;
-      line-height: 45px;
-      text-align: center;
-      text-decoration: none;
-      -webkit-text-size-adjust: none;
-      mso-hide: all;
-    }
-     
-    @media only screen and (max-width: 600px) {
-      .email-body_inner,
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><html xmlns="http://www.w3.org/1999/xhtml"><head>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+  
+<style type="text/css">*:not(br):not(tr):not(html) {
+font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif !important;
+-webkit-box-sizing: border-box !important;
+box-sizing: border-box !important
+}cite:before {
+content: "\2014 \0020" !important
+}@media only screen and (max-width: 600px){
+.email-body_inner,
       .email-footer {
-        width: 100% !important;
-      }
-    }
-  </style>
-</head>
-<body dir="ltr">
-  <table class="email-wrapper" width="100%" cellpadding="0" cellspacing="0">
-    <tr>
-      <td class="content">
-        <table class="email-content" width="100%" cellpadding="0" cellspacing="0">
+width: 100% !important
+}
+}
+</style></head>
+<body dir="ltr" style="height:100%;margin:0;line-height:1.4;background-color:#2c3e50;color:#74787E;-webkit-text-size-adjust:none;width:100%">
+  <table class="email-wrapper" width="100%" cellpadding="0" cellspacing="0" style="width:100%;margin:0;padding:0;background-color:#2c3e50">
+    <tbody><tr>
+      <td class="content" style="color:#74787E;font-size:15px;line-height:18px;align:center;padding:0">
+        <table class="email-content" width="100%" cellpadding="0" cellspacing="0" style="width:100%;margin:0;padding:0">
           
-          <tr>
-            <td class="email-masthead">
-              <a class="email-masthead_name" href="https://example-hermes.com/" target="_blank">
+          <tbody><tr>
+            <td class="email-masthead" style="color:#74787E;font-size:15px;line-height:18px;padding:25px 0;text-align:center">
+              <a class="email-masthead_name" href="https://example-hermes.com/" target="_blank" style="font-size:16px;font-weight:bold;color:#2F3133;text-decoration:none;text-shadow:0 1px 0 white">
                 
-                  <img src="http://www.duchess-france.org/wp-content/uploads/2016/01/gopher.png" class="email-logo" />
+                  <img src="https://github.com/matcornic/hermes/blob/master/examples/gopher.png?raw=true" class="email-logo" style="max-height:50px"/>
                 
                 </a>
             </td>
@@ -265,16 +33,16 @@
 
           
           <tr>
-            <td class="email-body" width="100%">
-              <table class="email-body_inner" align="center" width="570" cellpadding="0" cellspacing="0">
+            <td class="email-body" width="100%" style="color:#74787E;font-size:15px;line-height:18px;width:100%;margin:0;padding:0;border-top:1px solid #EDEFF2;border-bottom:1px solid #EDEFF2;background-color:#FFF">
+              <table class="email-body_inner" align="center" width="570" cellpadding="0" cellspacing="0" style="width:570px;margin:0 auto;padding:0">
                 
-                <tr>
-                  <td class="content-cell">
-                    <h1>Hi Jon Snow,</h1>
+                <tbody><tr>
+                  <td class="content-cell" style="color:#74787E;font-size:15px;line-height:18px;padding:35px">
+                    <h1 style="margin-top:0;color:#2F3133;font-size:19px;font-weight:bold">Hi Jon Snow,</h1>
                     
                         
                           
-                            <p>Your order has been processed successfully.</p>
+                            <p style="margin-top:0;color:#74787E;font-size:16px;line-height:1.5em">Your order has been processed successfully.</p>
                           
                         
                     
@@ -287,82 +55,38 @@
                         
                         
                         
-                          <table class="data-wrapper" width="100%" cellpadding="0" cellspacing="0">
-                            <tr>
-                              <td colspan="2">
-                                <table class="data-table" width="100%" cellpadding="0" cellspacing="0">
-                                  <tr>
+                          <table class="data-wrapper" width="100%" cellpadding="0" cellspacing="0" style="width:100%;margin:0;padding:35px 0">
+                            <tbody><tr>
+                              <td colspan="2" style="padding:10px 5px;color:#74787E;font-size:15px;line-height:18px">
+                                <table class="data-table" width="100%" cellpadding="0" cellspacing="0" style="width:100%;margin:0">
+                                  <tbody><tr>
                                     
                                     
-                                      <th
-                                        
-                                          
-                                          
-                                            width="20%"
-                                          
-                                          
-                                          
-                                        
-                                      >
-                                        <p>Item</p>
+                                      <th width="20%" style="text-align:left;padding:0px 5px;padding-bottom:8px;border-bottom:1px solid #EDEFF2">
+                                        <p style="margin-top:0;line-height:1.5em;margin:0;color:#9BA2AB;font-size:12px">Item</p>
                                       </th>
                                     
-                                      <th
-                                        
-                                          
-                                          
-                                          
-                                          
-                                        
-                                      >
-                                        <p>Description</p>
+                                      <th style="text-align:left;padding:0px 5px;padding-bottom:8px;border-bottom:1px solid #EDEFF2">
+                                        <p style="margin-top:0;line-height:1.5em;margin:0;color:#9BA2AB;font-size:12px">Description</p>
                                       </th>
                                     
-                                      <th
-                                        
-                                          
-                                          
-                                            width="15%"
-                                          
-                                          
-                                          
-                                            style="text-align:right"
-                                          
-                                        
-                                      >
-                                        <p>Price</p>
+                                      <th width="15%" style="padding:0px 5px;padding-bottom:8px;border-bottom:1px solid #EDEFF2;text-align:right">
+                                        <p style="margin-top:0;line-height:1.5em;margin:0;color:#9BA2AB;font-size:12px">Price</p>
                                       </th>
                                     
                                   </tr>
                                   
                                     <tr>
                                       
-                                        <td
-                                          
-                                            
-                                            
-                                          
-                                        >
+                                        <td style="padding:10px 5px;color:#74787E;font-size:15px;line-height:18px">
                                           Golang
                                         </td>
                                       
-                                        <td
-                                          
-                                            
-                                            
-                                          
-                                        >
+                                        <td style="padding:10px 5px;color:#74787E;font-size:15px;line-height:18px">
                                           Open source programming language that makes it easy to build simple, reliable, and efficient software
                                         </td>
                                       
-                                        <td
-                                          
-                                            
-                                            
-                                              style="text-align:right"
-                                            
-                                          
-                                        >
+                                        <td style="padding:10px 5px;color:#74787E;font-size:15px;line-height:18px;text-align:right">
                                           $10.99
                                         </td>
                                       
@@ -370,41 +94,24 @@
                                   
                                     <tr>
                                       
-                                        <td
-                                          
-                                            
-                                            
-                                          
-                                        >
+                                        <td style="padding:10px 5px;color:#74787E;font-size:15px;line-height:18px">
                                           Hermes
                                         </td>
                                       
-                                        <td
-                                          
-                                            
-                                            
-                                          
-                                        >
+                                        <td style="padding:10px 5px;color:#74787E;font-size:15px;line-height:18px">
                                           Programmatically create beautiful e-mails using Golang.
                                         </td>
                                       
-                                        <td
-                                          
-                                            
-                                            
-                                              style="text-align:right"
-                                            
-                                          
-                                        >
+                                        <td style="padding:10px 5px;color:#74787E;font-size:15px;line-height:18px;text-align:right">
                                           $1.99
                                         </td>
                                       
                                     </tr>
                                   
-                                </table>
+                                </tbody></table>
                               </td>
                             </tr>
-                          </table>
+                          </tbody></table>
                         
                       
 
@@ -412,18 +119,36 @@
                       
                         
                           
-                            <p>You can check the status of your order and more in your dashboard:</p>
-                            <table class="body-action" align="center" width="100%" cellpadding="0" cellspacing="0">
-                              <tr>
-                                <td align="center">
-                                  <div>
-                                    <a href="https://hermes-example.com/dashboard" class="button" style=" " target="_blank">
+                            <p style="margin-top:0;color:#74787E;font-size:16px;line-height:1.5em">You can check the status of your order and more in your dashboard:</p>
+                            <!--[if mso]>
+                            <div style="margin: 30px auto">
+                              <v:roundrect xmlns:v="urn:schemas-microsoft-com:vml" 
+                                xmlns:w="urn:schemas-microsoft-com:office:word" 
+                                href="https://hermes-example.com/dashboard" 
+                                style="height:45px;v-text-anchor:middle;width:570px;background-color:#00948D;"
+                                arcsize="0%" 
+                                strokecolor="#00948D" fillcolor="#00948D"
+                                >
+                                <w:anchorlock/>
+                                <center style="color: #FFFFFF;font-size: 15px;text-align: center;font-family:sans-serif;font-weight:bold;">
+                                  Go to Dashboard
+                                </center>
+                              </v:roundrect>
+                            </div>
+                            <![endif]-->
+                            <!--[if !mso]><!-- -->
+                            <table class="body-action" align="center" width="100%" cellpadding="0" cellspacing="0" style="width:100%;margin:30px auto;padding:0;text-align:center">
+                              <tbody><tr>
+                                <td align="center" style="padding:10px 5px;color:#74787E;font-size:15px;line-height:18px">
+                                  <div>                                    
+                                    <a href="https://hermes-example.com/dashboard" class="button" style="display:inline-block;width:100%;background-color:#00948d;font-size:15px;line-height:45px;text-align:center;text-decoration:none;-webkit-text-size-adjust:none;mso-hide:all;color:#ffffff" target="_blank">
                                       Go to Dashboard
                                     </a>
                                   </div>
                                 </td>
                               </tr>
-                            </table>
+                            </tbody></table>
+                            <!--<![endif]-->
                           
                         
                       
@@ -431,21 +156,21 @@
                     
                     
 
-                    <p>
+                    <p style="margin-top:0;color:#74787E;font-size:16px;line-height:1.5em">
                       Yours truly,
-                      <br />
+                      <br/>
                       Hermes
                     </p>
 
                     
                        
-                        <table class="body-sub">
+                        <table class="body-sub" style="width:100%;margin-top:25px;padding-top:25px;border-top:1px solid #EDEFF2;table-layout:fixed">
                           <tbody>
                               
                                 <tr>
-                                  <td>
-                                    <p class="sub">If you’re having trouble with the button &#39;Go to Dashboard&#39;, copy and paste the URL below into your web browser.</p>
-                                    <p class="sub"><a href="https://hermes-example.com/dashboard">https://hermes-example.com/dashboard</a></p>
+                                  <td style="padding:10px 5px;color:#74787E;font-size:15px;line-height:18px">
+                                    <p class="sub" style="margin-top:0;color:#74787E;line-height:1.5em;font-size:12px">If you’re having trouble with the button &#39;Go to Dashboard&#39;, copy and paste the URL below into your web browser.</p>
+                                    <p class="sub" style="margin-top:0;color:#74787E;line-height:1.5em;font-size:12px"><a href="https://hermes-example.com/dashboard" style="color:#3869D4;word-break:break-all">https://hermes-example.com/dashboard</a></p>
                                   </td>
                                 </tr>
                               
@@ -455,25 +180,26 @@
                     
                   </td>
                 </tr>
-              </table>
+              </tbody></table>
             </td>
           </tr>
           <tr>
-            <td>
-              <table class="email-footer" align="center" width="570" cellpadding="0" cellspacing="0">
-                <tr>
-                  <td class="content-cell">
-                    <p class="sub center">
-                      Copyright © 2019 Hermes. All rights reserved.
+            <td style="padding:10px 5px;color:#74787E;font-size:15px;line-height:18px">
+              <table class="email-footer" align="center" width="570" cellpadding="0" cellspacing="0" style="width:570px;margin:0 auto;padding:0;text-align:center">
+                <tbody><tr>
+                  <td class="content-cell" style="color:#74787E;font-size:15px;line-height:18px;padding:35px">
+                    <p class="sub center" style="margin-top:0;line-height:1.5em;color:#eaeaea;font-size:12px;text-align:center">
+                      Copyright © 2020 Hermes. All rights reserved.
                     </p>
                   </td>
                 </tr>
-              </table>
+              </tbody></table>
             </td>
           </tr>
-        </table>
+        </tbody></table>
       </td>
     </tr>
-  </table>
-</body>
-</html>
+  </tbody></table>
+
+
+</body></html>

--- a/examples/flat/flat.receipt.txt
+++ b/examples/flat/flat.receipt.txt
@@ -21,4 +21,4 @@ You can check the status of your order and more in your dashboard: https://herme
 Yours truly,
 Hermes - https://example-hermes.com/
 
-Copyright © 2019 Hermes. All rights reserved.
+Copyright © 2020 Hermes. All rights reserved.

--- a/examples/flat/flat.reset.html
+++ b/examples/flat/flat.reset.html
@@ -1,263 +1,31 @@
-
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-  <style type="text/css" rel="stylesheet" media="all">
-     
-    *:not(br):not(tr):not(html) {
-      font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif;
-      -webkit-box-sizing: border-box;
-      box-sizing: border-box;
-    }
-    body {
-      width: 100% !important;
-      height: 100%;
-      margin: 0;
-      line-height: 1.4;
-      background-color: #2c3e50;
-      color: #74787E;
-      -webkit-text-size-adjust: none;
-    }
-    a {
-      color: #3869D4;
-    }
-
-     
-    .email-wrapper {
-      width: 100%;
-      margin: 0;
-      padding: 0;
-      background-color: #2c3e50;
-    }
-    .email-content {
-      width: 100%;
-      margin: 0;
-      padding: 0;
-    }
-     
-    .email-masthead {
-      padding: 25px 0;
-      text-align: center;
-    }
-    .email-masthead_logo {
-      max-width: 400px;
-      border: 0;
-    }
-    .email-masthead_name {
-      font-size: 16px;
-      font-weight: bold;
-      color: #2F3133;
-      text-decoration: none;
-      text-shadow: 0 1px 0 white;
-    }
-    .email-logo {
-      max-height: 50px;
-    }
-     
-    .email-body {
-      width: 100%;
-      margin: 0;
-      padding: 0;
-      border-top: 1px solid #EDEFF2;
-      border-bottom: 1px solid #EDEFF2;
-      background-color: #FFF;
-    }
-    .email-body_inner {
-      width: 570px;
-      margin: 0 auto;
-      padding: 0;
-    }
-    .email-footer {
-      width: 570px;
-      margin: 0 auto;
-      padding: 0;
-      text-align: center;
-    }
-    .email-footer p {
-      color: #eaeaea;
-    }
-    .body-action {
-      width: 100%;
-      margin: 30px auto;
-      padding: 0;
-      text-align: center;
-    }
-
-    .body-dictionary {
-      width: 100%;
-      overflow: hidden;
-      margin: 20px auto 20px;
-      padding: 0;
-    }
-    .body-dictionary dt {
-      clear: both;
-      color: #000;
-      font-weight: bold;
-      float: left;
-      width: 50%;
-      padding: 0;
-      margin: 0;
-      margin-bottom: 0.3em;
-    }
-    .body-dictionary dd {
-      float: left;
-      width: 50%;
-      padding: 0;
-      margin: 0;
-    }
-    .body-sub {
-      margin-top: 25px;
-      padding-top: 25px;
-      border-top: 1px solid #EDEFF2;
-      table-layout: fixed;
-    }
-    .body-sub a {
-      word-break: break-all;
-    }
-    .content-cell {
-      padding: 35px;
-    }
-    .align-right {
-      text-align: right;
-    }
-     
-    h1 {
-      margin-top: 0;
-      color: #2F3133;
-      font-size: 19px;
-      font-weight: bold;
-    }
-    h2 {
-      margin-top: 0;
-      color: #2F3133;
-      font-size: 16px;
-      font-weight: bold;
-    }
-    h3 {
-      margin-top: 0;
-      color: #2F3133;
-      font-size: 14px;
-      font-weight: bold;
-    }
-    blockquote {
-      margin: 1.7rem 0;
-      padding-left: 0.85rem;
-      border-left: 10px solid #F0F2F4;
-    }
-    blockquote p {
-        font-size: 1.1rem;
-        color: #999;
-    }
-    blockquote cite {
-        display: block;
-        text-align: right;
-        color: #666;
-        font-size: 1.2rem;
-    }
-    cite {
-      display: block;
-      font-size: 0.925rem; 
-    }
-    cite:before {
-      content: "\2014 \0020";
-    }
-    p {
-      margin-top: 0;
-      color: #74787E;
-      font-size: 16px;
-      line-height: 1.5em;
-    }
-    p.sub {
-      font-size: 12px;
-    }
-    p.center {
-      text-align: center;
-    }
-    table {
-      width: 100%;
-    }
-    th {
-      padding: 0px 5px;
-      padding-bottom: 8px;
-      border-bottom: 1px solid #EDEFF2;
-    }
-    th p {
-      margin: 0;
-      color: #9BA2AB;
-      font-size: 12px;
-    }
-    td {
-      padding: 10px 5px;
-      color: #74787E;
-      font-size: 15px;
-      line-height: 18px;
-    }
-    .content {
-      align: center;
-      padding: 0;
-    }
-     
-    .data-wrapper {
-      width: 100%;
-      margin: 0;
-      padding: 35px 0;
-    }
-    .data-table {
-      width: 100%;
-      margin: 0;
-    }
-    .data-table th {
-      text-align: left;
-      padding: 0px 5px;
-      padding-bottom: 8px;
-      border-bottom: 1px solid #EDEFF2;
-    }
-    .data-table th p {
-      margin: 0;
-      color: #9BA2AB;
-      font-size: 12px;
-    }
-    .data-table td {
-      padding: 10px 5px;
-      color: #74787E;
-      font-size: 15px;
-      line-height: 18px;
-    }
-     
-    .button {
-      display: inline-block;
-      width: 100%;
-      background-color: #00948d;
-      color: #ffffff;
-      font-size: 15px;
-      line-height: 45px;
-      text-align: center;
-      text-decoration: none;
-      -webkit-text-size-adjust: none;
-      mso-hide: all;
-    }
-     
-    @media only screen and (max-width: 600px) {
-      .email-body_inner,
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><html xmlns="http://www.w3.org/1999/xhtml"><head>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+  
+<style type="text/css">*:not(br):not(tr):not(html) {
+font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif !important;
+-webkit-box-sizing: border-box !important;
+box-sizing: border-box !important
+}cite:before {
+content: "\2014 \0020" !important
+}@media only screen and (max-width: 600px){
+.email-body_inner,
       .email-footer {
-        width: 100% !important;
-      }
-    }
-  </style>
-</head>
-<body dir="ltr">
-  <table class="email-wrapper" width="100%" cellpadding="0" cellspacing="0">
-    <tr>
-      <td class="content">
-        <table class="email-content" width="100%" cellpadding="0" cellspacing="0">
+width: 100% !important
+}
+}
+</style></head>
+<body dir="ltr" style="height:100%;margin:0;line-height:1.4;background-color:#2c3e50;color:#74787E;-webkit-text-size-adjust:none;width:100%">
+  <table class="email-wrapper" width="100%" cellpadding="0" cellspacing="0" style="width:100%;margin:0;padding:0;background-color:#2c3e50">
+    <tbody><tr>
+      <td class="content" style="color:#74787E;font-size:15px;line-height:18px;align:center;padding:0">
+        <table class="email-content" width="100%" cellpadding="0" cellspacing="0" style="width:100%;margin:0;padding:0">
           
-          <tr>
-            <td class="email-masthead">
-              <a class="email-masthead_name" href="https://example-hermes.com/" target="_blank">
+          <tbody><tr>
+            <td class="email-masthead" style="color:#74787E;font-size:15px;line-height:18px;padding:25px 0;text-align:center">
+              <a class="email-masthead_name" href="https://example-hermes.com/" target="_blank" style="font-size:16px;font-weight:bold;color:#2F3133;text-decoration:none;text-shadow:0 1px 0 white">
                 
-                  <img src="http://www.duchess-france.org/wp-content/uploads/2016/01/gopher.png" class="email-logo" />
+                  <img src="https://github.com/matcornic/hermes/blob/master/examples/gopher.png?raw=true" class="email-logo" style="max-height:50px"/>
                 
                 </a>
             </td>
@@ -265,16 +33,16 @@
 
           
           <tr>
-            <td class="email-body" width="100%">
-              <table class="email-body_inner" align="center" width="570" cellpadding="0" cellspacing="0">
+            <td class="email-body" width="100%" style="color:#74787E;font-size:15px;line-height:18px;width:100%;margin:0;padding:0;border-top:1px solid #EDEFF2;border-bottom:1px solid #EDEFF2;background-color:#FFF">
+              <table class="email-body_inner" align="center" width="570" cellpadding="0" cellspacing="0" style="width:570px;margin:0 auto;padding:0">
                 
-                <tr>
-                  <td class="content-cell">
-                    <h1>Hi Jon Snow,</h1>
+                <tbody><tr>
+                  <td class="content-cell" style="color:#74787E;font-size:15px;line-height:18px;padding:35px">
+                    <h1 style="margin-top:0;color:#2F3133;font-size:19px;font-weight:bold">Hi Jon Snow,</h1>
                     
                         
                           
-                            <p>You have received this email because a password reset request for Hermes account was received.</p>
+                            <p style="margin-top:0;color:#74787E;font-size:16px;line-height:1.5em">You have received this email because a password reset request for Hermes account was received.</p>
                           
                         
                     
@@ -293,18 +61,36 @@
                       
                         
                           
-                            <p>Click the button below to reset your password:</p>
-                            <table class="body-action" align="center" width="100%" cellpadding="0" cellspacing="0">
-                              <tr>
-                                <td align="center">
-                                  <div>
-                                    <a href="https://hermes-example.com/reset-password?token=d9729feb74992cc3482b350163a1a010" class="button" style="background-color: #DC4D2F; " target="_blank">
+                            <p style="margin-top:0;color:#74787E;font-size:16px;line-height:1.5em">Click the button below to reset your password:</p>
+                            <!--[if mso]>
+                            <div style="margin: 30px auto">
+                              <v:roundrect xmlns:v="urn:schemas-microsoft-com:vml" 
+                                xmlns:w="urn:schemas-microsoft-com:office:word" 
+                                href="https://hermes-example.com/reset-password?token=d9729feb74992cc3482b350163a1a010" 
+                                style="height:45px;v-text-anchor:middle;width:570px;background-color:#DC4D2F;"
+                                arcsize="0%" 
+                                strokecolor="#DC4D2F" fillcolor="#DC4D2F"
+                                >
+                                <w:anchorlock/>
+                                <center style="color: #FFFFFF;font-size: 15px;text-align: center;font-family:sans-serif;font-weight:bold;">
+                                  Reset your password
+                                </center>
+                              </v:roundrect>
+                            </div>
+                            <![endif]-->
+                            <!--[if !mso]><!-- -->
+                            <table class="body-action" align="center" width="100%" cellpadding="0" cellspacing="0" style="width:100%;margin:30px auto;padding:0;text-align:center">
+                              <tbody><tr>
+                                <td align="center" style="padding:10px 5px;color:#74787E;font-size:15px;line-height:18px">
+                                  <div>                                    
+                                    <a href="https://hermes-example.com/reset-password?token=d9729feb74992cc3482b350163a1a010" class="button" style="display:inline-block;width:100%;font-size:15px;line-height:45px;text-align:center;text-decoration:none;-webkit-text-size-adjust:none;mso-hide:all;color:#ffffff;background-color:#DC4D2F" target="_blank">
                                       Reset your password
                                     </a>
                                   </div>
                                 </td>
                               </tr>
-                            </table>
+                            </tbody></table>
+                            <!--<![endif]-->
                           
                         
                       
@@ -313,26 +99,26 @@
                      
                         
                           
-                            <p>If you did not request a password reset, no further action is required on your part.</p>
+                            <p style="margin-top:0;color:#74787E;font-size:16px;line-height:1.5em">If you did not request a password reset, no further action is required on your part.</p>
                           
                         
                       
 
-                    <p>
+                    <p style="margin-top:0;color:#74787E;font-size:16px;line-height:1.5em">
                       Thanks,
-                      <br />
+                      <br/>
                       Hermes
                     </p>
 
                     
                        
-                        <table class="body-sub">
+                        <table class="body-sub" style="width:100%;margin-top:25px;padding-top:25px;border-top:1px solid #EDEFF2;table-layout:fixed">
                           <tbody>
                               
                                 <tr>
-                                  <td>
-                                    <p class="sub">If you’re having trouble with the button &#39;Reset your password&#39;, copy and paste the URL below into your web browser.</p>
-                                    <p class="sub"><a href="https://hermes-example.com/reset-password?token=d9729feb74992cc3482b350163a1a010">https://hermes-example.com/reset-password?token=d9729feb74992cc3482b350163a1a010</a></p>
+                                  <td style="padding:10px 5px;color:#74787E;font-size:15px;line-height:18px">
+                                    <p class="sub" style="margin-top:0;color:#74787E;line-height:1.5em;font-size:12px">If you’re having trouble with the button &#39;Reset your password&#39;, copy and paste the URL below into your web browser.</p>
+                                    <p class="sub" style="margin-top:0;color:#74787E;line-height:1.5em;font-size:12px"><a href="https://hermes-example.com/reset-password?token=d9729feb74992cc3482b350163a1a010" style="color:#3869D4;word-break:break-all">https://hermes-example.com/reset-password?token=d9729feb74992cc3482b350163a1a010</a></p>
                                   </td>
                                 </tr>
                               
@@ -342,25 +128,26 @@
                     
                   </td>
                 </tr>
-              </table>
+              </tbody></table>
             </td>
           </tr>
           <tr>
-            <td>
-              <table class="email-footer" align="center" width="570" cellpadding="0" cellspacing="0">
-                <tr>
-                  <td class="content-cell">
-                    <p class="sub center">
-                      Copyright © 2019 Hermes. All rights reserved.
+            <td style="padding:10px 5px;color:#74787E;font-size:15px;line-height:18px">
+              <table class="email-footer" align="center" width="570" cellpadding="0" cellspacing="0" style="width:570px;margin:0 auto;padding:0;text-align:center">
+                <tbody><tr>
+                  <td class="content-cell" style="color:#74787E;font-size:15px;line-height:18px;padding:35px">
+                    <p class="sub center" style="margin-top:0;line-height:1.5em;color:#eaeaea;font-size:12px;text-align:center">
+                      Copyright © 2020 Hermes. All rights reserved.
                     </p>
                   </td>
                 </tr>
-              </table>
+              </tbody></table>
             </td>
           </tr>
-        </table>
+        </tbody></table>
       </td>
     </tr>
-  </table>
-</body>
-</html>
+  </tbody></table>
+
+
+</body></html>

--- a/examples/flat/flat.reset.txt
+++ b/examples/flat/flat.reset.txt
@@ -11,4 +11,4 @@ If you did not request a password reset, no further action is required on your p
 Thanks,
 Hermes - https://example-hermes.com/
 
-Copyright © 2019 Hermes. All rights reserved.
+Copyright © 2020 Hermes. All rights reserved.

--- a/examples/flat/flat.welcome.html
+++ b/examples/flat/flat.welcome.html
@@ -1,263 +1,31 @@
-
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-  <style type="text/css" rel="stylesheet" media="all">
-     
-    *:not(br):not(tr):not(html) {
-      font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif;
-      -webkit-box-sizing: border-box;
-      box-sizing: border-box;
-    }
-    body {
-      width: 100% !important;
-      height: 100%;
-      margin: 0;
-      line-height: 1.4;
-      background-color: #2c3e50;
-      color: #74787E;
-      -webkit-text-size-adjust: none;
-    }
-    a {
-      color: #3869D4;
-    }
-
-     
-    .email-wrapper {
-      width: 100%;
-      margin: 0;
-      padding: 0;
-      background-color: #2c3e50;
-    }
-    .email-content {
-      width: 100%;
-      margin: 0;
-      padding: 0;
-    }
-     
-    .email-masthead {
-      padding: 25px 0;
-      text-align: center;
-    }
-    .email-masthead_logo {
-      max-width: 400px;
-      border: 0;
-    }
-    .email-masthead_name {
-      font-size: 16px;
-      font-weight: bold;
-      color: #2F3133;
-      text-decoration: none;
-      text-shadow: 0 1px 0 white;
-    }
-    .email-logo {
-      max-height: 50px;
-    }
-     
-    .email-body {
-      width: 100%;
-      margin: 0;
-      padding: 0;
-      border-top: 1px solid #EDEFF2;
-      border-bottom: 1px solid #EDEFF2;
-      background-color: #FFF;
-    }
-    .email-body_inner {
-      width: 570px;
-      margin: 0 auto;
-      padding: 0;
-    }
-    .email-footer {
-      width: 570px;
-      margin: 0 auto;
-      padding: 0;
-      text-align: center;
-    }
-    .email-footer p {
-      color: #eaeaea;
-    }
-    .body-action {
-      width: 100%;
-      margin: 30px auto;
-      padding: 0;
-      text-align: center;
-    }
-
-    .body-dictionary {
-      width: 100%;
-      overflow: hidden;
-      margin: 20px auto 20px;
-      padding: 0;
-    }
-    .body-dictionary dt {
-      clear: both;
-      color: #000;
-      font-weight: bold;
-      float: left;
-      width: 50%;
-      padding: 0;
-      margin: 0;
-      margin-bottom: 0.3em;
-    }
-    .body-dictionary dd {
-      float: left;
-      width: 50%;
-      padding: 0;
-      margin: 0;
-    }
-    .body-sub {
-      margin-top: 25px;
-      padding-top: 25px;
-      border-top: 1px solid #EDEFF2;
-      table-layout: fixed;
-    }
-    .body-sub a {
-      word-break: break-all;
-    }
-    .content-cell {
-      padding: 35px;
-    }
-    .align-right {
-      text-align: right;
-    }
-     
-    h1 {
-      margin-top: 0;
-      color: #2F3133;
-      font-size: 19px;
-      font-weight: bold;
-    }
-    h2 {
-      margin-top: 0;
-      color: #2F3133;
-      font-size: 16px;
-      font-weight: bold;
-    }
-    h3 {
-      margin-top: 0;
-      color: #2F3133;
-      font-size: 14px;
-      font-weight: bold;
-    }
-    blockquote {
-      margin: 1.7rem 0;
-      padding-left: 0.85rem;
-      border-left: 10px solid #F0F2F4;
-    }
-    blockquote p {
-        font-size: 1.1rem;
-        color: #999;
-    }
-    blockquote cite {
-        display: block;
-        text-align: right;
-        color: #666;
-        font-size: 1.2rem;
-    }
-    cite {
-      display: block;
-      font-size: 0.925rem; 
-    }
-    cite:before {
-      content: "\2014 \0020";
-    }
-    p {
-      margin-top: 0;
-      color: #74787E;
-      font-size: 16px;
-      line-height: 1.5em;
-    }
-    p.sub {
-      font-size: 12px;
-    }
-    p.center {
-      text-align: center;
-    }
-    table {
-      width: 100%;
-    }
-    th {
-      padding: 0px 5px;
-      padding-bottom: 8px;
-      border-bottom: 1px solid #EDEFF2;
-    }
-    th p {
-      margin: 0;
-      color: #9BA2AB;
-      font-size: 12px;
-    }
-    td {
-      padding: 10px 5px;
-      color: #74787E;
-      font-size: 15px;
-      line-height: 18px;
-    }
-    .content {
-      align: center;
-      padding: 0;
-    }
-     
-    .data-wrapper {
-      width: 100%;
-      margin: 0;
-      padding: 35px 0;
-    }
-    .data-table {
-      width: 100%;
-      margin: 0;
-    }
-    .data-table th {
-      text-align: left;
-      padding: 0px 5px;
-      padding-bottom: 8px;
-      border-bottom: 1px solid #EDEFF2;
-    }
-    .data-table th p {
-      margin: 0;
-      color: #9BA2AB;
-      font-size: 12px;
-    }
-    .data-table td {
-      padding: 10px 5px;
-      color: #74787E;
-      font-size: 15px;
-      line-height: 18px;
-    }
-     
-    .button {
-      display: inline-block;
-      width: 100%;
-      background-color: #00948d;
-      color: #ffffff;
-      font-size: 15px;
-      line-height: 45px;
-      text-align: center;
-      text-decoration: none;
-      -webkit-text-size-adjust: none;
-      mso-hide: all;
-    }
-     
-    @media only screen and (max-width: 600px) {
-      .email-body_inner,
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><html xmlns="http://www.w3.org/1999/xhtml"><head>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+  
+<style type="text/css">*:not(br):not(tr):not(html) {
+font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif !important;
+-webkit-box-sizing: border-box !important;
+box-sizing: border-box !important
+}cite:before {
+content: "\2014 \0020" !important
+}@media only screen and (max-width: 600px){
+.email-body_inner,
       .email-footer {
-        width: 100% !important;
-      }
-    }
-  </style>
-</head>
-<body dir="ltr">
-  <table class="email-wrapper" width="100%" cellpadding="0" cellspacing="0">
-    <tr>
-      <td class="content">
-        <table class="email-content" width="100%" cellpadding="0" cellspacing="0">
+width: 100% !important
+}
+}
+</style></head>
+<body dir="ltr" style="height:100%;margin:0;line-height:1.4;background-color:#2c3e50;color:#74787E;-webkit-text-size-adjust:none;width:100%">
+  <table class="email-wrapper" width="100%" cellpadding="0" cellspacing="0" style="width:100%;margin:0;padding:0;background-color:#2c3e50">
+    <tbody><tr>
+      <td class="content" style="color:#74787E;font-size:15px;line-height:18px;align:center;padding:0">
+        <table class="email-content" width="100%" cellpadding="0" cellspacing="0" style="width:100%;margin:0;padding:0">
           
-          <tr>
-            <td class="email-masthead">
-              <a class="email-masthead_name" href="https://example-hermes.com/" target="_blank">
+          <tbody><tr>
+            <td class="email-masthead" style="color:#74787E;font-size:15px;line-height:18px;padding:25px 0;text-align:center">
+              <a class="email-masthead_name" href="https://example-hermes.com/" target="_blank" style="font-size:16px;font-weight:bold;color:#2F3133;text-decoration:none;text-shadow:0 1px 0 white">
                 
-                  <img src="http://www.duchess-france.org/wp-content/uploads/2016/01/gopher.png" class="email-logo" />
+                  <img src="https://github.com/matcornic/hermes/blob/master/examples/gopher.png?raw=true" class="email-logo" style="max-height:50px"/>
                 
                 </a>
             </td>
@@ -265,16 +33,16 @@
 
           
           <tr>
-            <td class="email-body" width="100%">
-              <table class="email-body_inner" align="center" width="570" cellpadding="0" cellspacing="0">
+            <td class="email-body" width="100%" style="color:#74787E;font-size:15px;line-height:18px;width:100%;margin:0;padding:0;border-top:1px solid #EDEFF2;border-bottom:1px solid #EDEFF2;background-color:#FFF">
+              <table class="email-body_inner" align="center" width="570" cellpadding="0" cellspacing="0" style="width:570px;margin:0 auto;padding:0">
                 
-                <tr>
-                  <td class="content-cell">
-                    <h1>Hi Jon Snow,</h1>
+                <tbody><tr>
+                  <td class="content-cell" style="color:#74787E;font-size:15px;line-height:18px;padding:35px">
+                    <h1 style="margin-top:0;color:#2F3133;font-size:19px;font-weight:bold">Hi Jon Snow,</h1>
                     
                         
                           
-                            <p>Welcome to Hermes! We&#39;re very excited to have you on board.</p>
+                            <p style="margin-top:0;color:#74787E;font-size:16px;line-height:1.5em">Welcome to Hermes! We&#39;re very excited to have you on board.</p>
                           
                         
                     
@@ -282,16 +50,16 @@
 
                        
                         
-                          <dl class="body-dictionary">
+                          <dl class="body-dictionary" style="width:100%;overflow:hidden;margin:20px auto 20px;padding:0">
                             
-                              <dt>Firstname:</dt>
-                              <dd>Jon</dd>
+                              <dt style="clear:both;color:#000;font-weight:bold;float:left;width:50%;padding:0;margin:0;margin-bottom:0.3em">Firstname:</dt>
+                              <dd style="float:left;width:50%;padding:0;margin:0">Jon</dd>
                             
-                              <dt>Lastname:</dt>
-                              <dd>Snow</dd>
+                              <dt style="clear:both;color:#000;font-weight:bold;float:left;width:50%;padding:0;margin:0;margin-bottom:0.3em">Lastname:</dt>
+                              <dd style="float:left;width:50%;padding:0;margin:0">Snow</dd>
                             
-                              <dt>Birthday:</dt>
-                              <dd>01/01/283</dd>
+                              <dt style="clear:both;color:#000;font-weight:bold;float:left;width:50%;padding:0;margin:0;margin-bottom:0.3em">Birthday:</dt>
+                              <dd style="float:left;width:50%;padding:0;margin:0">01/01/283</dd>
                             
                           </dl>
                         
@@ -308,18 +76,36 @@
                       
                         
                           
-                            <p>To get started with Hermes, please click here:</p>
-                            <table class="body-action" align="center" width="100%" cellpadding="0" cellspacing="0">
-                              <tr>
-                                <td align="center">
-                                  <div>
-                                    <a href="https://hermes-example.com/confirm?token=d9729feb74992cc3482b350163a1a010" class="button" style=" " target="_blank">
+                            <p style="margin-top:0;color:#74787E;font-size:16px;line-height:1.5em">To get started with Hermes, please click here:</p>
+                            <!--[if mso]>
+                            <div style="margin: 30px auto">
+                              <v:roundrect xmlns:v="urn:schemas-microsoft-com:vml" 
+                                xmlns:w="urn:schemas-microsoft-com:office:word" 
+                                href="https://hermes-example.com/confirm?token=d9729feb74992cc3482b350163a1a010" 
+                                style="height:45px;v-text-anchor:middle;width:570px;background-color:#00948D;"
+                                arcsize="0%" 
+                                strokecolor="#00948D" fillcolor="#00948D"
+                                >
+                                <w:anchorlock/>
+                                <center style="color: #FFFFFF;font-size: 15px;text-align: center;font-family:sans-serif;font-weight:bold;">
+                                  Confirm your account
+                                </center>
+                              </v:roundrect>
+                            </div>
+                            <![endif]-->
+                            <!--[if !mso]><!-- -->
+                            <table class="body-action" align="center" width="100%" cellpadding="0" cellspacing="0" style="width:100%;margin:30px auto;padding:0;text-align:center">
+                              <tbody><tr>
+                                <td align="center" style="padding:10px 5px;color:#74787E;font-size:15px;line-height:18px">
+                                  <div>                                    
+                                    <a href="https://hermes-example.com/confirm?token=d9729feb74992cc3482b350163a1a010" class="button" style="display:inline-block;width:100%;background-color:#00948d;font-size:15px;line-height:45px;text-align:center;text-decoration:none;-webkit-text-size-adjust:none;mso-hide:all;color:#ffffff" target="_blank">
                                       Confirm your account
                                     </a>
                                   </div>
                                 </td>
                               </tr>
-                            </table>
+                            </tbody></table>
+                            <!--<![endif]-->
                           
                         
                       
@@ -328,26 +114,26 @@
                      
                         
                           
-                            <p>Need help, or have questions? Just reply to this email, we&#39;d love to help.</p>
+                            <p style="margin-top:0;color:#74787E;font-size:16px;line-height:1.5em">Need help, or have questions? Just reply to this email, we&#39;d love to help.</p>
                           
                         
                       
 
-                    <p>
+                    <p style="margin-top:0;color:#74787E;font-size:16px;line-height:1.5em">
                       Yours truly,
-                      <br />
+                      <br/>
                       Hermes
                     </p>
 
                     
                        
-                        <table class="body-sub">
+                        <table class="body-sub" style="width:100%;margin-top:25px;padding-top:25px;border-top:1px solid #EDEFF2;table-layout:fixed">
                           <tbody>
                               
                                 <tr>
-                                  <td>
-                                    <p class="sub">If you’re having trouble with the button &#39;Confirm your account&#39;, copy and paste the URL below into your web browser.</p>
-                                    <p class="sub"><a href="https://hermes-example.com/confirm?token=d9729feb74992cc3482b350163a1a010">https://hermes-example.com/confirm?token=d9729feb74992cc3482b350163a1a010</a></p>
+                                  <td style="padding:10px 5px;color:#74787E;font-size:15px;line-height:18px">
+                                    <p class="sub" style="margin-top:0;color:#74787E;line-height:1.5em;font-size:12px">If you’re having trouble with the button &#39;Confirm your account&#39;, copy and paste the URL below into your web browser.</p>
+                                    <p class="sub" style="margin-top:0;color:#74787E;line-height:1.5em;font-size:12px"><a href="https://hermes-example.com/confirm?token=d9729feb74992cc3482b350163a1a010" style="color:#3869D4;word-break:break-all">https://hermes-example.com/confirm?token=d9729feb74992cc3482b350163a1a010</a></p>
                                   </td>
                                 </tr>
                               
@@ -357,25 +143,26 @@
                     
                   </td>
                 </tr>
-              </table>
+              </tbody></table>
             </td>
           </tr>
           <tr>
-            <td>
-              <table class="email-footer" align="center" width="570" cellpadding="0" cellspacing="0">
-                <tr>
-                  <td class="content-cell">
-                    <p class="sub center">
-                      Copyright © 2019 Hermes. All rights reserved.
+            <td style="padding:10px 5px;color:#74787E;font-size:15px;line-height:18px">
+              <table class="email-footer" align="center" width="570" cellpadding="0" cellspacing="0" style="width:570px;margin:0 auto;padding:0;text-align:center">
+                <tbody><tr>
+                  <td class="content-cell" style="color:#74787E;font-size:15px;line-height:18px;padding:35px">
+                    <p class="sub center" style="margin-top:0;line-height:1.5em;color:#eaeaea;font-size:12px;text-align:center">
+                      Copyright © 2020 Hermes. All rights reserved.
                     </p>
                   </td>
                 </tr>
-              </table>
+              </tbody></table>
             </td>
           </tr>
-        </table>
+        </tbody></table>
       </td>
     </tr>
-  </table>
-</body>
-</html>
+  </tbody></table>
+
+
+</body></html>

--- a/examples/flat/flat.welcome.txt
+++ b/examples/flat/flat.welcome.txt
@@ -15,4 +15,4 @@ Need help, or have questions? Just reply to this email, we'd love to help.
 Yours truly,
 Hermes - https://example-hermes.com/
 
-Copyright © 2019 Hermes. All rights reserved.
+Copyright © 2020 Hermes. All rights reserved.

--- a/examples/main.go
+++ b/examples/main.go
@@ -23,7 +23,7 @@ func main() {
 		Product: hermes.Product{
 			Name: "Hermes",
 			Link: "https://example-hermes.com/",
-			Logo: "http://www.duchess-france.org/wp-content/uploads/2016/01/gopher.png",
+			Logo: "https://github.com/matcornic/hermes/blob/master/examples/gopher.png?raw=true",
 		},
 	}
 	sendEmails := os.Getenv("HERMES_SEND_EMAILS") == "true"
@@ -51,7 +51,7 @@ func main() {
 	// Send emails only when requested
 	if sendEmails {
 		port, _ := strconv.Atoi(os.Getenv("HERMES_SMTP_PORT"))
-		password :=  os.Getenv("HERMES_SMTP_PASSWORD")
+		password := os.Getenv("HERMES_SMTP_PASSWORD")
 		SMTPUser := os.Getenv("HERMES_SMTP_USER")
 		if password == "" {
 			fmt.Printf("Enter SMTP password of '%s' account: ", SMTPUser)
@@ -59,12 +59,12 @@ func main() {
 			password = string(bytePassword)
 		}
 		smtpConfig := smtpAuthentication{
-			Server:  os.Getenv("HERMES_SMTP_SERVER"),
-			Port: port,
-			SenderEmail: os.Getenv("HERMES_SENDER_EMAIL"),
+			Server:         os.Getenv("HERMES_SMTP_SERVER"),
+			Port:           port,
+			SenderEmail:    os.Getenv("HERMES_SENDER_EMAIL"),
 			SenderIdentity: os.Getenv("HERMES_SENDER_IDENTITY"),
-			SMTPPassword: password,
-			SMTPUser: SMTPUser,
+			SMTPPassword:   password,
+			SMTPUser:       SMTPUser,
 		}
 		options := sendOptions{
 			To: os.Getenv("HERMES_TO"),
@@ -72,7 +72,7 @@ func main() {
 		for _, theme := range themes {
 			h.Theme = theme
 			for _, e := range examples {
-				options.Subject = "Testing Hermes - Theme "+h.Theme.Name() + " - Example " + e.Name()
+				options.Subject = "Hermes | " + h.Theme.Name() + " | " + e.Name()
 				fmt.Printf("Sending email '%s'...\n", options.Subject)
 				htmlBytes, err := ioutil.ReadFile(fmt.Sprintf("%v/%v.%v.html", h.Theme.Name(), h.Theme.Name(), e.Name()))
 				if err != nil {
@@ -82,7 +82,7 @@ func main() {
 				if err != nil {
 					panic(err)
 				}
-				err = send(smtpConfig, options,string(htmlBytes), string(txtBytes))
+				err = send(smtpConfig, options, string(htmlBytes), string(txtBytes))
 				if err != nil {
 					panic(err)
 				}

--- a/examples/maintenance.go
+++ b/examples/maintenance.go
@@ -26,8 +26,6 @@ Services will be unavailable based on the following schedule:
 | Service B | 4AM to 5AM |
 | Service C | 5AM to 6AM |
 
----
-
 Feel free to contact us for any question regarding this matter at [support@hermes-example.com](mailto:support@hermes-example.com) or in our [Gitter](https://gitter.im/)
 
 `,

--- a/flat.go
+++ b/flat.go
@@ -154,8 +154,8 @@ func (dt *Flat) HTMLTemplate() string {
       font-weight: bold;
     }
     blockquote {
-      margin: 1.7rem 0;
-      padding-left: 0.85rem;
+      margin: 25px 0;
+      padding-left: 10px;
       border-left: 10px solid #F0F2F4;
     }
     blockquote p {
@@ -363,10 +363,27 @@ func (dt *Flat) HTMLTemplate() string {
                         {{ if gt (len .) 0 }}
                           {{ range $action := . }}
                             <p>{{ $action.Instructions }}</p>
+                            {{safe "<!--[if mso]>" }}
+                            <div style="margin: 30px auto">
+                              <v:roundrect xmlns:v="urn:schemas-microsoft-com:vml" 
+                                xmlns:w="urn:schemas-microsoft-com:office:word" 
+                                href="{{ $action.Button.Link }}" 
+                                style="height:45px;v-text-anchor:middle;width:570px;background-color:{{ if $action.Button.Color }}{{ $action.Button.Color }}{{else}}#00948D{{ end }};"
+                                arcsize="0%" 
+                                {{ if $action.Button.Color }}strokecolor="{{ $action.Button.Color }}" fillcolor="{{ $action.Button.Color }}"{{ else }}strokecolor="#00948D" fillcolor="#00948D"{{ end }}
+                                >
+                                <w:anchorlock/>
+                                <center style="color: {{ if $action.Button.TextColor }}{{ $action.Button.TextColor }}{{else}}#FFFFFF{{ end }};font-size: 15px;text-align: center;font-family:sans-serif;font-weight:bold;">
+                                  {{ $action.Button.Text }}
+                                </center>
+                              </v:roundrect>
+                            </div>
+                            {{safe "<![endif]-->" }}
+                            {{safe "<!--[if !mso]><!-- -->"}}
                             <table class="body-action" align="center" width="100%" cellpadding="0" cellspacing="0">
                               <tr>
                                 <td align="center">
-                                  <div>
+                                  <div>                                    
                                     <a href="{{ $action.Button.Link }}" class="button" style="{{ with $action.Button.Color }}background-color: {{ . }};{{ end }} {{ with $action.Button.TextColor }}color: {{ . }};{{ end }}" target="_blank">
                                       {{ $action.Button.Text }}
                                     </a>
@@ -374,6 +391,7 @@ func (dt *Flat) HTMLTemplate() string {
                                 </td>
                               </tr>
                             </table>
+                            {{safe "<!--<![endif]-->"}}
                           {{ end }}
                         {{ end }}
                       {{ end }}

--- a/go.mod
+++ b/go.mod
@@ -3,10 +3,12 @@ module github.com/matcornic/hermes/v2
 require (
 	github.com/Masterminds/semver v1.4.2 // indirect
 	github.com/Masterminds/sprig v2.16.0+incompatible
+	github.com/PuerkitoBio/goquery v1.5.0 // indirect
 	github.com/aokoli/goutils v1.0.1 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/go-gomail/gomail v0.0.0-20160411212932-81ebce5c23df
 	github.com/google/uuid v1.0.0 // indirect
+	github.com/gorilla/css v1.0.0 // indirect
 	github.com/huandu/xstrings v1.2.0 // indirect
 	github.com/imdario/mergo v0.3.6
 	github.com/jaytaylor/html2text v0.0.0-20180606194806-57d518f124b0
@@ -18,11 +20,14 @@ require (
 	github.com/shurcooL/sanitized_anchor_name v1.0.0 // indirect
 	github.com/ssor/bom v0.0.0-20170718123548-6386211fdfcf // indirect
 	github.com/stretchr/testify v1.2.2
+	github.com/vanng822/css v0.0.0-20190504095207-a21e860bcd04 // indirect
+	github.com/vanng822/go-premailer v0.0.0-20191214114701-be27abe028fe
 	golang.org/x/crypto v0.0.0-20181029175232-7e6ffbd03851
-	golang.org/x/net v0.0.0-20181029044818-c44066c5c816 // indirect
 	golang.org/x/sys v0.0.0-20190225065934-cc5685c2db12 // indirect
 	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 // indirect
 	gopkg.in/yaml.v2 v2.2.1 // indirect
 )
 
 replace gopkg.in/russross/blackfriday.v2 v2.0.1 => github.com/russross/blackfriday/v2 v2.0.1
+
+go 1.13

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,10 @@ github.com/Masterminds/semver v1.4.2 h1:WBLTQ37jOCzSLtXNdoo8bNM8876KhNqOKvrlGITg
 github.com/Masterminds/semver v1.4.2/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
 github.com/Masterminds/sprig v2.16.0+incompatible h1:QZbMUPxRQ50EKAq3LFMnxddMu88/EUUG3qmxwtDmPsY=
 github.com/Masterminds/sprig v2.16.0+incompatible/go.mod h1:y6hNFY5UBTIWBxnzTeuNhlNS5hqE0NB0E6fgfo2Br3o=
+github.com/PuerkitoBio/goquery v1.5.0 h1:uGvmFXOA73IKluu/F84Xd1tt/z07GYm8X49XKHP7EJk=
+github.com/PuerkitoBio/goquery v1.5.0/go.mod h1:qD2PgZ9lccMbQlc7eEOjaeRlFQON7xY8kdmcsrnKqMg=
+github.com/andybalholm/cascadia v1.0.0 h1:hOCXnnZ5A+3eVDX8pvgl4kofXv2ELss0bKcqRySc45o=
+github.com/andybalholm/cascadia v1.0.0/go.mod h1:GsXiBklL0woXo1j/WYWtSYYC4ouU9PqHO0sqidkEA4Y=
 github.com/aokoli/goutils v1.0.1 h1:7fpzNGoJ3VA8qcrm++XEE1QUe0mIwNeLa02Nwq7RDkg=
 github.com/aokoli/goutils v1.0.1/go.mod h1:SijmP0QR8LtwsmDs8Yii5Z/S4trXFGFC2oO5g9DP+DQ=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
@@ -10,6 +14,8 @@ github.com/go-gomail/gomail v0.0.0-20160411212932-81ebce5c23df h1:Bao6dhmbTA1KFV
 github.com/go-gomail/gomail v0.0.0-20160411212932-81ebce5c23df/go.mod h1:GJr+FCSXshIwgHBtLglIg9M2l2kQSi6QjVAngtzI08Y=
 github.com/google/uuid v1.0.0 h1:b4Gk+7WdP/d3HZH8EJsZpvV7EtDOgaZLtnaNGIu1adA=
 github.com/google/uuid v1.0.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/gorilla/css v1.0.0 h1:BQqNyPTi50JCFMTw/b67hByjMVXZRwGha6wxVGkeihY=
+github.com/gorilla/css v1.0.0/go.mod h1:Dn721qIggHpt4+EFCcTLTU/vk5ySda2ReITrtgBl60c=
 github.com/huandu/xstrings v1.2.0 h1:yPeWdRnmynF7p+lLYz0H2tthW9lqhMJrQV/U7yy4wX0=
 github.com/huandu/xstrings v1.2.0/go.mod h1:DvyZB1rfVYsBIigL8HwpZgxHwXozlTgGqn63UyNX5k4=
 github.com/imdario/mergo v0.3.6 h1:xTNEAn+kxVO7dTZGu0CegyqKZmoWFI0rF8UxjlB2d28=
@@ -35,10 +41,17 @@ github.com/ssor/bom v0.0.0-20170718123548-6386211fdfcf h1:pvbZ0lM0XWPBqUKqFU8cma
 github.com/ssor/bom v0.0.0-20170718123548-6386211fdfcf/go.mod h1:RJID2RhlZKId02nZ62WenDCkgHFerpIOmW0iT7GKmXM=
 github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
+github.com/vanng822/css v0.0.0-20190504095207-a21e860bcd04 h1:L0rPdfzq43+NV8rfIx2kA4iSSLRj2jN5ijYHoeXRwvQ=
+github.com/vanng822/css v0.0.0-20190504095207-a21e860bcd04/go.mod h1:tcnB1voG49QhCrwq1W0w5hhGasvOg+VQp9i9H1rCM1w=
+github.com/vanng822/go-premailer v0.0.0-20191214114701-be27abe028fe h1:9YnI5plmy+ad6BM+JCLJb2ZV7/TNiE5l7SNKfumYKgc=
+github.com/vanng822/go-premailer v0.0.0-20191214114701-be27abe028fe/go.mod h1:JTFJA/t820uFDoyPpErFQ3rb3amdZoPtxcKervG0OE4=
 golang.org/x/crypto v0.0.0-20181029175232-7e6ffbd03851 h1:I3xmTQr7a0n8SA6urVBFKB7hsVRLLN2LBITNbXPj1/w=
 golang.org/x/crypto v0.0.0-20181029175232-7e6ffbd03851/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
+golang.org/x/net v0.0.0-20180218175443-cbe0f9307d01/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20181029044818-c44066c5c816 h1:mVFkLpejdFLXVUv9E42f3XJVfMdqd0IVLVIVLjZWn5o=
 golang.org/x/net v0.0.0-20181029044818-c44066c5c816/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
+golang.org/x/net v0.0.0-20181114220301-adae6a3d119a h1:gOpx8G595UYyvj8UK4+OFyY4rx037g3fmfhe5SasG3U=
+golang.org/x/net v0.0.0-20181114220301-adae6a3d119a/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/sys v0.0.0-20190225065934-cc5685c2db12 h1:Zw7eRv6INHGfu15LVRN1vrrwusJbnfJjAZn3D1VkQIE=
 golang.org/x/sys v0.0.0-20190225065934-cc5685c2db12/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=

--- a/hermes.go
+++ b/hermes.go
@@ -142,7 +142,7 @@ func setDefaultHermesValues(h *Hermes) error {
 		TextDirection: defaultTextDirection,
 		Product: Product{
 			Name:        "Hermes",
-			Copyright:   "Copyright © 2019 Hermes. All rights reserved.",
+			Copyright:   "Copyright © 2020 Hermes. All rights reserved.",
 			TroubleText: "If you’re having trouble with the button '{ACTION}', copy and paste the URL below into your web browser.",
 		},
 	}

--- a/hermes_test.go
+++ b/hermes_test.go
@@ -449,7 +449,7 @@ func TestHermes_Default(t *testing.T) {
 	assert.Equal(t, h.TextDirection, TDLeftToRight)
 	assert.Equal(t, h.Theme, new(Default))
 	assert.Equal(t, h.Product.Name, "Hermes")
-	assert.Equal(t, h.Product.Copyright, "Copyright © 2019 Hermes. All rights reserved.")
+	assert.Equal(t, h.Product.Copyright, "Copyright © 2020 Hermes. All rights reserved.")
 
 	assert.Empty(t, email.Body.Actions)
 	assert.Empty(t, email.Body.Dictionary)

--- a/hermes_test.go
+++ b/hermes_test.go
@@ -41,7 +41,8 @@ func (ed *SimpleExample) getExample() (Hermes, Email) {
 			Copyright: "Copyright © Hermes-Test",
 			Logo:      "http://www.duchess-france.org/wp-content/uploads/2016/01/gopher.png",
 		},
-		TextDirection: TDLeftToRight,
+		TextDirection:      TDLeftToRight,
+		DisableCSSInlining: true,
 	}
 
 	email := Email{
@@ -161,6 +162,7 @@ func (ed *WithTitleInsteadOfNameExample) getExample() (Hermes, Email) {
 			Name: "Hermes",
 			Link: "http://hermes.com",
 		},
+		DisableCSSInlining: true,
 	}
 
 	email := Email{
@@ -193,6 +195,7 @@ func (ed *WithGreetingDifferentThanDefault) getExample() (Hermes, Email) {
 			Name: "Hermes",
 			Link: "http://hermes.com",
 		},
+		DisableCSSInlining: true,
 	}
 
 	email := Email{
@@ -225,6 +228,7 @@ func (ed *WithSignatureDifferentThanDefault) getExample() (Hermes, Email) {
 			Name: "Hermes",
 			Link: "http://hermes.com",
 		},
+		DisableCSSInlining: true,
 	}
 
 	email := Email{
@@ -257,6 +261,7 @@ func (ed *WithFreeMarkdownContent) getExample() (Hermes, Email) {
 			Name: "Hermes",
 			Link: "http://hermes.com",
 		},
+		DisableCSSInlining: true,
 	}
 
 	email := Email{
@@ -409,7 +414,8 @@ func TestHermes_TextDirectionAsDefault(t *testing.T) {
 			Name: "Hermes",
 			Link: "http://hermes.com",
 		},
-		TextDirection: "not-existing", // Wrong text-direction
+		TextDirection:      "not-existing", // Wrong text-direction
+		DisableCSSInlining: true,
 	}
 
 	email := Email{


### PR DESCRIPTION
Great news, a friend of mine has lent me a Windows with a licensed Outlook. So I can fix the Outlook compatibility issue. 

So this PR contains code for:
- Fix outlook missing button #59
- Fix outlook quotes display
- Add CSS inlining by default with https://github.com/vanng822/go-premailer/premailer (now Outlook displays the text as centered)

=> Replaces PR #48 

Hey @kauffj @loeffel-io @vjeantet @dmuriel @elliots  🙌
Can you test this PR on your side ? 

It worked for me on a Windows 10 with latest version of Outlook. I think it's still perfectible, but it does the work.

Edit: the size of the button now adapts to content in default theme.