### PR TITLE
allow themes to provide pre-parsed templates

### DIFF
--- a/default.go
+++ b/default.go
@@ -1,5 +1,12 @@
 package hermes
 
+import "html/template"
+
+var (
+	defaultHTMLTemplate      = template.Must(TemplateBase().Parse(defaultHTML))
+	defaultPlainTextTemplate = template.Must(TemplateBase().Parse(defaultPlainText))
+)
+
 // Default is the theme by default
 type Default struct{}
 
@@ -10,7 +17,24 @@ func (dt *Default) Name() string {
 
 // HTMLTemplate returns a Golang template that will generate an HTML email.
 func (dt *Default) HTMLTemplate() string {
-	return `
+	return defaultHTML
+}
+
+func (dt *Default) ParsedHTMLTemplate(base *template.Template) (*template.Template, error) {
+	return defaultHTMLTemplate, nil
+}
+
+// PlainTextTemplate returns a Golang template that will generate an plain text email.
+func (dt *Default) PlainTextTemplate() string {
+	return defaultPlainText
+}
+
+func (dt *Default) ParsedPlainTextTemplate(base *template.Template) (*template.Template, error) {
+	return defaultPlainTextTemplate, nil
+}
+
+const (
+	defaultHTML = `
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
@@ -495,11 +519,8 @@ func (dt *Default) HTMLTemplate() string {
 </body>
 </html>
 `
-}
 
-// PlainTextTemplate returns a Golang template that will generate an plain text email.
-func (dt *Default) PlainTextTemplate() string {
-	return `<h2>{{if .Email.Body.Title }}{{ .Email.Body.Title }}{{ else }}{{ .Email.Body.Greeting }} {{ .Email.Body.Name }},{{ end }}</h2>
+	defaultPlainText = `<h2>{{if .Email.Body.Title }}{{ .Email.Body.Title }}{{ else }}{{ .Email.Body.Greeting }} {{ .Email.Body.Name }},{{ end }}</h2>
 {{ with .Email.Body.Intros }}
   {{ range $line := . }}
     <p>{{ $line }}</p>
@@ -561,4 +582,4 @@ func (dt *Default) PlainTextTemplate() string {
 
 <p>{{.Hermes.Product.Copyright}}</p>
 `
-}
+)

--- a/flat.go
+++ b/flat.go
@@ -1,5 +1,12 @@
 package hermes
 
+import "html/template"
+
+var (
+	flatHTMLTemplate      = template.Must(TemplateBase().Parse(flatHTML))
+	flatPlainTextTemplate = template.Must(TemplateBase().Parse(flatPlainText))
+)
+
 // Flat is a theme
 type Flat struct{}
 
@@ -10,7 +17,24 @@ func (dt *Flat) Name() string {
 
 // HTMLTemplate returns a Golang template that will generate an HTML email.
 func (dt *Flat) HTMLTemplate() string {
-	return `
+	return flatHTML
+}
+
+func (dt *Flat) ParsedHTMLTemplate(base *template.Template) (*template.Template, error) {
+	return flatHTMLTemplate, nil
+}
+
+// PlainTextTemplate returns a Golang template that will generate an plain text email.
+func (dt *Flat) PlainTextTemplate() string {
+	return flatPlainText
+}
+
+func (dt *Flat) ParsedPlainTextTemplate(base *template.Template) (*template.Template, error) {
+	return flatPlainTextTemplate, nil
+}
+
+const (
+	flatHTML = `
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
@@ -493,11 +517,8 @@ func (dt *Flat) HTMLTemplate() string {
 </body>
 </html>
 `
-}
 
-// PlainTextTemplate returns a Golang template that will generate an plain text email.
-func (dt *Flat) PlainTextTemplate() string {
-	return `<h2>{{if .Email.Body.Title }}{{ .Email.Body.Title }}{{ else }}{{ .Email.Body.Greeting }} {{ .Email.Body.Name }}{{ end }},</h2>
+	flatPlainText = `<h2>{{if .Email.Body.Title }}{{ .Email.Body.Title }}{{ else }}{{ .Email.Body.Greeting }} {{ .Email.Body.Name }}{{ end }},</h2>
 {{ with .Email.Body.Intros }}
   {{ range $line := . }}
     <p>{{ $line }}</p>
@@ -559,4 +580,4 @@ func (dt *Flat) PlainTextTemplate() string {
 
 <p>{{.Hermes.Product.Copyright}}</p>
 `
-}
+)


### PR DESCRIPTION
Parsing a static template every time that it's used is a pretty big performance overhead. This pull request adds some optional interfaces that can be defined by themes to allow them to avoid needing to do that every time.