### PR TITLE
Delete new line between signature and product name

### DIFF
--- a/flat.go
+++ b/flat.go
@@ -446,7 +446,7 @@ func (dt *Flat) HTMLTemplate() string {
 
                     <p>
                       {{.Email.Body.Signature}},
-                      <br />
+                      <br>
                       {{.Hermes.Product.Name}}
                     </p>
 


### PR DESCRIPTION
```
<p>
    {{.Email.Body.Signature}},
    <br/>
    {{.Hermes.Product.Name}}
</p>
```
  
  Put the product name right under the signature: `<br/>  ->  <br>`