### PR TITLE
Added an optional unsubscribe link

### DIFF
--- a/default.go
+++ b/default.go
@@ -480,6 +480,11 @@ func (dt *Default) HTMLTemplate() string {
               <table class="email-footer" align="center" width="570" cellpadding="0" cellspacing="0">
                 <tr>
                   <td class="content-cell">
+                    {{ if .Email.Body.UnsubscribeLink }}
+                    <p class="sub center">
+                      <a href="{{ .Email.Body.UnsubscribeLink | url }}" target="_blank">{{ if .Email.Body.UnsubscribeText }}{{ .Email.Body.UnsubscribeText }}{{ else }}Unsubscribe{{ end }}</a>
+                    </p>
+                    {{ end }}
                     <p class="sub center">
                       {{.Hermes.Product.Copyright}}
                     </p>
@@ -558,6 +563,10 @@ func (dt *Default) PlainTextTemplate() string {
   {{ end }}
 {{ end }}
 <p>{{.Email.Body.Signature}},<br>{{.Hermes.Product.Name}} - {{.Hermes.Product.Link}}</p>
+
+{{ if .Email.Body.UnsubscribeLink }}
+<p><a href="{{ .Email.Body.UnsubscribeLink }}">{{ if .Email.Body.UnsubscribeText }}{{ .Email.Body.UnsubscribeText }}{{ else }}Unsubscribe{{ end }}</a></p>
+{{ end }}
 
 <p>{{.Hermes.Product.Copyright}}</p>
 `

--- a/examples/default/default.welcome.html
+++ b/examples/default/default.welcome.html
@@ -167,6 +167,11 @@ width: 100% !important
               <table class="email-footer" align="center" width="570" cellpadding="0" cellspacing="0" style="width:570px;margin:0 auto;padding:0;text-align:center">
                 <tbody><tr>
                   <td class="content-cell" style="color:#74787E;font-size:15px;line-height:18px;padding:35px">
+                    
+                    <p class="sub center" style="margin-top:0;line-height:1.5em;color:#AEAEAE;font-size:12px;text-align:center">
+                      <a href="https://hermes-example.com/unsubscribe?token=d9729feb74992cc3482b350163a1a010" target="_blank" style="color:#3869D4">Unsubscribe</a>
+                    </p>
+                    
                     <p class="sub center" style="margin-top:0;line-height:1.5em;color:#AEAEAE;font-size:12px;text-align:center">
                       Copyright © 2025 Hermes. All rights reserved.
                     </p>

--- a/examples/default/default.welcome.txt
+++ b/examples/default/default.welcome.txt
@@ -15,4 +15,6 @@ Need help, or have questions? Just reply to this email, we'd love to help.
 Yours truly,
 Hermes - https://example-hermes.com/
 
+Unsubscribe ( https://hermes-example.com/unsubscribe?token=d9729feb74992cc3482b350163a1a010 )
+
 Copyright © 2025 Hermes. All rights reserved.

--- a/examples/flat/flat.welcome.html
+++ b/examples/flat/flat.welcome.html
@@ -159,6 +159,11 @@ width: 100% !important
               <table class="email-footer" align="center" width="570" cellpadding="0" cellspacing="0" style="width:570px;margin:0 auto;padding:0;text-align:center">
                 <tbody><tr>
                   <td class="content-cell" style="color:#74787E;font-size:15px;line-height:18px;padding:35px">
+                    
+                    <p class="sub center" style="margin-top:0;line-height:1.5em;color:#eaeaea;font-size:12px;text-align:center">
+                      <a href="https://hermes-example.com/unsubscribe?token=d9729feb74992cc3482b350163a1a010" target="_blank" style="color:#3869D4">Unsubscribe</a>
+                    </p>
+                    
                     <p class="sub center" style="margin-top:0;line-height:1.5em;color:#eaeaea;font-size:12px;text-align:center">
                       Copyright © 2025 Hermes. All rights reserved.
                     </p>

--- a/examples/flat/flat.welcome.txt
+++ b/examples/flat/flat.welcome.txt
@@ -15,4 +15,6 @@ Need help, or have questions? Just reply to this email, we'd love to help.
 Yours truly,
 Hermes - https://example-hermes.com/
 
+Unsubscribe ( https://hermes-example.com/unsubscribe?token=d9729feb74992cc3482b350163a1a010 )
+
 Copyright © 2025 Hermes. All rights reserved.

--- a/examples/welcome.go
+++ b/examples/welcome.go
@@ -35,6 +35,7 @@ func (w *welcome) Email() hermes.Email {
 			Outros: []string{
 				"Need help, or have questions? Just reply to this email, we'd love to help.",
 			},
+			UnsubscribeLink: "https://hermes-example.com/unsubscribe?token=d9729feb74992cc3482b350163a1a010",
 		},
 	}
 }

--- a/flat.go
+++ b/flat.go
@@ -478,6 +478,11 @@ func (dt *Flat) HTMLTemplate() string {
               <table class="email-footer" align="center" width="570" cellpadding="0" cellspacing="0">
                 <tr>
                   <td class="content-cell">
+                    {{ if .Email.Body.UnsubscribeLink }}
+                    <p class="sub center">
+                      <a href="{{ .Email.Body.UnsubscribeLink | url }}" target="_blank">{{ if .Email.Body.UnsubscribeText }}{{ .Email.Body.UnsubscribeText }}{{ else }}Unsubscribe{{ end }}</a>
+                    </p>
+                    {{ end }}
                     <p class="sub center">
                       {{.Hermes.Product.Copyright}}
                     </p>
@@ -556,6 +561,10 @@ func (dt *Flat) PlainTextTemplate() string {
   {{ end }}
 {{ end }}
 <p>{{.Email.Body.Signature}},<br>{{.Hermes.Product.Name}} - {{.Hermes.Product.Link}}</p>
+
+{{ if .Email.Body.UnsubscribeLink }}
+<p><a href="{{ .Email.Body.UnsubscribeLink }}">{{ if .Email.Body.UnsubscribeText }}{{ .Email.Body.UnsubscribeText }}{{ else }}Unsubscribe{{ end }}</a></p>
+{{ end }}
 
 <p>{{.Hermes.Product.Copyright}}</p>
 `

--- a/hermes.go
+++ b/hermes.go
@@ -73,8 +73,10 @@ type Body struct {
 	Outros       []string // Outro sentences, last displayed in the email
 	Greeting     string   // Greeting for the contacted person (default to 'Hi')
 	Signature    string   // Signature for the contacted person (default to 'Yours truly')
-	Title        string   // Title replaces the greeting+name when set
-	FreeMarkdown Markdown // Free markdown content that replaces all content other than header and footer
+	Title            string // Title replaces the greeting+name when set
+	FreeMarkdown     Markdown // Free markdown content that replaces all content other than header and footer
+	UnsubscribeLink  string   // Optional URL for an unsubscribe link in the email footer
+	UnsubscribeText  string   // Optional text for the unsubscribe link (defaults to 'Unsubscribe')
 }
 
 // ToHTML converts Markdown to HTML

--- a/hermes_test.go
+++ b/hermes_test.go
@@ -120,6 +120,7 @@ func (ed *SimpleExample) assertHTMLContent(t *testing.T, r string) {
 	assert.Contains(t, r, "#22BC66", "Action: Button should have given color")
 	assert.Contains(t, r, "https://hermes-example.com/confirm?token=d9729feb74992cc3482b350163a1a010", "Action: Button should have link")
 	assert.Contains(t, r, "Need help, or have questions", "Outro: Should have outro")
+	assert.NotContains(t, r, "Unsubscribe", "Unsubscribe: Should not appear when link is not set")
 }
 
 func (ed *SimpleExample) assertPlainTextContent(t *testing.T, r string) {
@@ -150,6 +151,7 @@ func (ed *SimpleExample) assertPlainTextContent(t *testing.T, r string) {
 	assert.NotContains(t, r, "#22BC66", "Action: Button should not have color in plain text")
 	assert.Contains(t, r, "https://hermes-example.com/confirm?token=d9729feb74992cc3482b350163a1a010", "Action: Even if button is not possible in plain text, it should have the link")
 	assert.Contains(t, r, "Need help, or have questions", "Outro: Should have outro")
+	assert.NotContains(t, r, "Unsubscribe", "Unsubscribe: Should not appear when link is not set")
 }
 
 type WithTitleInsteadOfNameExample struct {
@@ -291,6 +293,76 @@ func (ed *WithInviteCode) assertHTMLContent(t *testing.T, r string) {
 func (ed *WithInviteCode) assertPlainTextContent(t *testing.T, r string) {
 	assert.Contains(t, r, "Here is your invite code", "Should contains the instruction")
 	assert.Contains(t, r, "123456", "Should contain the short code")
+}
+
+type WithUnsubscribeLink struct {
+	theme Theme
+}
+
+func (ed *WithUnsubscribeLink) getExample() (Hermes, Email) {
+	h := Hermes{
+		Theme: ed.theme,
+		Product: Product{
+			Name: "Hermes",
+			Link: "http://hermes.com",
+		},
+		DisableCSSInlining: true,
+	}
+
+	email := Email{
+		Body{
+			Name:            "Jon Snow",
+			UnsubscribeLink: "https://hermes-example.com/unsubscribe?token=abc123",
+		},
+	}
+
+	return h, email
+}
+
+func (ed *WithUnsubscribeLink) assertHTMLContent(t *testing.T, r string) {
+	assert.Contains(t, r, `href="https://hermes-example.com/unsubscribe?token=abc123"`, "Unsubscribe: Should find the unsubscribe link")
+	assert.Contains(t, r, ">Unsubscribe<", "Unsubscribe: Should use default link text")
+}
+
+func (ed *WithUnsubscribeLink) assertPlainTextContent(t *testing.T, r string) {
+	assert.Contains(t, r, "https://hermes-example.com/unsubscribe?token=abc123", "Unsubscribe: Should find the unsubscribe link")
+	assert.Contains(t, r, "Unsubscribe", "Unsubscribe: Should use default link text")
+}
+
+type WithUnsubscribeLinkCustomText struct {
+	theme Theme
+}
+
+func (ed *WithUnsubscribeLinkCustomText) getExample() (Hermes, Email) {
+	h := Hermes{
+		Theme: ed.theme,
+		Product: Product{
+			Name: "Hermes",
+			Link: "http://hermes.com",
+		},
+		DisableCSSInlining: true,
+	}
+
+	email := Email{
+		Body{
+			Name:            "Jon Snow",
+			UnsubscribeLink: "https://hermes-example.com/unsubscribe?token=abc123",
+			UnsubscribeText: "Manage email preferences",
+		},
+	}
+
+	return h, email
+}
+
+func (ed *WithUnsubscribeLinkCustomText) assertHTMLContent(t *testing.T, r string) {
+	assert.Contains(t, r, `href="https://hermes-example.com/unsubscribe?token=abc123"`, "Unsubscribe: Should find the unsubscribe link")
+	assert.Contains(t, r, ">Manage email preferences<", "Unsubscribe: Should use custom link text")
+	assert.NotContains(t, r, ">Unsubscribe<", "Unsubscribe: Should not use default link text")
+}
+
+func (ed *WithUnsubscribeLinkCustomText) assertPlainTextContent(t *testing.T, r string) {
+	assert.Contains(t, r, "https://hermes-example.com/unsubscribe?token=abc123", "Unsubscribe: Should find the unsubscribe link")
+	assert.Contains(t, r, "Manage email preferences", "Unsubscribe: Should use custom link text")
 }
 
 type WithFreeMarkdownContent struct {
@@ -447,6 +519,26 @@ func TestThemeWithInviteCode(t *testing.T) {
 		t.Run(theme.Name(), func(t *testing.T) {
 			t.Parallel()
 			checkExample(t, &WithInviteCode{theme})
+		})
+	}
+}
+
+func TestThemeWithUnsubscribeLink(t *testing.T) {
+	t.Parallel()
+	for _, theme := range testedThemes {
+		t.Run(theme.Name(), func(t *testing.T) {
+			t.Parallel()
+			checkExample(t, &WithUnsubscribeLink{theme})
+		})
+	}
+}
+
+func TestThemeWithUnsubscribeLinkCustomText(t *testing.T) {
+	t.Parallel()
+	for _, theme := range testedThemes {
+		t.Run(theme.Name(), func(t *testing.T) {
+			t.Parallel()
+			checkExample(t, &WithUnsubscribeLinkCustomText{theme})
 		})
 	}
 }


### PR DESCRIPTION
Summary

- Add optional `UnsubscribeLink` and `UnsubscribeText` fields on `Body`
- Render the link in the footer of default and flat themes (HTML + plain text)
- Add theme tests and update the welcome example